### PR TITLE
Fix: Correct syntax errors and implement runner features

### DIFF
--- a/pkg/runner/containerd.go
+++ b/pkg/runner/containerd.go
@@ -312,96 +312,618 @@ func (r *defaultRunner) CtrExecInContainer(ctx context.Context, conn connector.C
 	return combinedOutput, nil
 }
 
+// CtrContainerInfo retrieves information about a specific container using ctr.
+// Corresponds to `ctr -n <namespace> container info <containerID>`.
+func (r *defaultRunner) CtrContainerInfo(ctx context.Context, conn connector.Connector, namespace, containerID string) (*CtrContainerInfo, error) {
+	if conn == nil { return nil, errors.New("connector cannot be nil for CtrContainerInfo") }
+	if namespace == "" { return nil, errors.New("namespace is required for CtrContainerInfo") }
+	if containerID == "" { return nil, errors.New("containerID is required for CtrContainerInfo") }
+
+	cmd := fmt.Sprintf("ctr -n %s container info %s", shellEscape(namespace), shellEscape(containerID))
+	// ctr container info output is not JSON by default, it's a custom format.
+	// We need to parse it. Example:
+	// Image: docker.io/library/alpine:latest
+	// Runtime: io.containerd.runc.v2
+	// Snapshotter: overlayfs
+	// Spec: ... (OCI Spec JSON)
+	// Labels:
+	//   io.cri-containerd.container.name: test-container
+	//   io.kubernetes.pod.namespace: default
+
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCtrTimeout})
+	if err != nil {
+		if strings.Contains(string(stderr), "No such container") || strings.Contains(string(stderr), "not found") {
+			return nil, nil // Not found, return nil, nil
+		}
+		return nil, errors.Wrapf(err, "ctr container info for %s in namespace %s failed. Stderr: %s", containerID, namespace, string(stderr))
+	}
+
+	info := CtrContainerInfo{ID: containerID}
+	labels := make(map[string]string)
+	inLabelsSection := false
+
+	scanner := bufio.NewScanner(strings.NewReader(string(stdout)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "Image:") {
+			info.Image = strings.TrimSpace(strings.TrimPrefix(line, "Image:"))
+		} else if strings.HasPrefix(line, "Runtime:") {
+			info.Runtime = strings.TrimSpace(strings.TrimPrefix(line, "Runtime:"))
+			// Example: "io.containerd.runc.v2" "args=[-c]"
+			parts := strings.Fields(info.Runtime)
+			if len(parts) > 0 {
+				info.Runtime = parts[0] // Keep only the runtime name
+			}
+		} else if strings.HasPrefix(line, "Labels:") {
+			inLabelsSection = true
+			continue
+		} else if strings.HasPrefix(line, "Spec:") || strings.HasPrefix(line, "Snapshotter:") || line == "" {
+			// If we encounter another top-level key or empty line, labels section ends.
+			inLabelsSection = false
+		}
+
+		if inLabelsSection {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+				// Remove quotes if present, as ctr output might have them for some label values
+				value = strings.Trim(value, "\"")
+				labels[key] = value
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse ctr container info output for %s", containerID)
+	}
+	info.Labels = labels
+
+	// Status is not directly available from `ctr container info`.
+	// It needs to be fetched from `ctr task info` or `ctr task ls`.
+	// For now, status will remain empty or be set by a separate call if needed.
+	// We can attempt a `ctr task ps <containerID>` to see if a task is running.
+	taskPsCmd := fmt.Sprintf("ctr -n %s task ps %s", shellEscape(namespace), shellEscape(containerID))
+	_, _, taskErr := conn.Exec(ctx, taskPsCmd, &connector.ExecOptions{Sudo: true, Timeout: 5 * time.Second}) // Short timeout for status check
+	if taskErr == nil {
+		info.Status = "RUNNING" // If `task ps` succeeds, assume running.
+	} else {
+		// If `task ps` fails, it could be STOPPED, CREATED, or other states.
+		// `no such process` usually means no active task.
+		if strings.Contains(taskErr.Error(), "no such process") || strings.Contains(taskErr.Error(), "not found") {
+			info.Status = "STOPPED" // Or "CREATED" - hard to distinguish without more info
+		} else {
+			// Some other error trying to get task status
+			// fmt.Fprintf(os.Stderr, "Warning: could not determine task status for %s: %v\n", containerID, taskErr)
+			info.Status = "UNKNOWN"
+		}
+	}
+
+
+	return &info, nil
+}
+
+
 // --- Containerd Configuration ---
 
-// GetContainerdConfig attempts to read and return parts of containerd's config.toml.
-// Simplified: returns mostly empty struct due to TOML parsing complexity in this environment.
+// GetContainerdConfig attempts to read and heuristically parse parts of containerd's config.toml.
+// Due to the lack of a TOML parser, this is a best-effort extraction of common simple values.
 func (r *defaultRunner) GetContainerdConfig(ctx context.Context, conn connector.Connector) (*ContainerdConfigOptions, error) {
-	if conn == nil { return nil, errors.New("connector cannot be nil") }
+	if conn == nil { return nil, errors.New("connector cannot be nil for GetContainerdConfig") }
 
-	// A real implementation would use a TOML library.
-	// For this simulation, we acknowledge the limitation.
-	// We could read the file and try to regex out specific simple things if needed, but not parse fully.
-	_, err := r.ReadFile(ctx, conn, containerdConfigPath)
+	configContentBytes, err := r.ReadFile(ctx, conn, containerdConfigPath)
 	if err != nil {
 		exists, _ := r.Exists(ctx, conn, containerdConfigPath)
-		if !exists { return &ContainerdConfigOptions{}, nil } // Not an error if not found, return empty
-		return nil, errors.Wrapf(err, "failed to read containerd config %s", containerdConfigPath)
+		if !exists {
+			return &ContainerdConfigOptions{}, nil // Not an error if not found, return empty config
+		}
+		return nil, errors.Wrapf(err, "failed to read containerd config file %s", containerdConfigPath)
 	}
-	// If file exists but cannot be parsed into ContainerdConfigOptions without a TOML library:
-	return &ContainerdConfigOptions{}, errors.New("GetContainerdConfig: TOML parsing not implemented, cannot populate options struct from file content")
+
+	if len(configContentBytes) == 0 {
+		return &ContainerdConfigOptions{}, nil // Empty file, return empty config
+	}
+
+	configContent := string(configContentBytes)
+	opts := &ContainerdConfigOptions{
+		RegistryMirrors: make(map[string][]string), // Initialize map
+	}
+
+	// Helper to extract simple string values like key = "value" or key = value
+	extractString := func(content, key string) *string {
+		// Regex to find key = "value" or key = 'value' or key = value_without_quotes
+		// It tries to handle comments by ensuring the line doesn't start with #
+		// This is still very basic.
+		re := regexp.MustCompile(fmt.Sprintf(`^\s*%s\s*=\s*(?:\"(.*?)\"|'(.*?)'|([^#\s]+))`, regexp.QuoteMeta(key)))
+		matches := re.FindStringSubmatch(content)
+		if len(matches) > 1 {
+			if matches[1] != "" { // double quotes
+				val := matches[1]
+				return &val
+			}
+			if matches[2] != "" { // single quotes
+				val := matches[2]
+				return &val
+			}
+			if matches[3] != "" { // no quotes
+				val := matches[3]
+				return &val
+			}
+		}
+		return nil
+	}
+	extractInt := func(content, key string) *int {
+		strValPtr := extractString(content, key)
+		if strValPtr != nil {
+			if intVal, errAtoi := strconv.Atoi(*strValPtr); errAtoi == nil {
+				return &intVal
+			}
+		}
+		return nil
+	}
+	extractBool := func(content, key string) *bool {
+		strValPtr := extractString(content, key)
+		if strValPtr != nil {
+			if boolVal, errParseBool := strconv.ParseBool(*strValPtr); errParseBool == nil {
+				return &boolVal
+			}
+		}
+		return nil
+	}
+
+	// Top-level options
+	opts.Version = extractInt(configContent, "version")
+	opts.Root = extractString(configContent, "root")
+	opts.State = extractString(configContent, "state")
+	// oom_score is usually not quoted
+	reOOM := regexp.MustCompile(`^\s*oom_score\s*=\s*(-?\d+)`)
+	oomMatches := reOOM.FindStringSubmatch(configContent)
+	if len(oomMatches) > 1 {
+		if oomVal, errAtoi := strconv.Atoi(oomMatches[1]); errAtoi == nil {
+			opts.OOMScore = &oomVal
+		}
+	}
+
+
+	// [grpc] section - find the section first
+	grpcSectionRegex := regexp.MustCompile(`(?s)\[grpc\](.*?)(\n\s*\[|\z)`)
+	grpcSectionMatch := grpcSectionRegex.FindStringSubmatch(configContent)
+	if len(grpcSectionMatch) > 1 {
+		grpcContent := grpcSectionMatch[1]
+		opts.GRPC = &ContainerdGRPCConfig{}
+		opts.GRPC.Address = extractString(grpcContent, "address")
+		opts.GRPC.UID = extractInt(grpcContent, "uid")
+		opts.GRPC.GID = extractInt(grpcContent, "gid")
+	}
+
+	// [plugins."io.containerd.grpc.v1.cri"] section
+	criPluginRegex := regexp.MustCompile(`(?s)\[plugins\.("io\.containerd\.grpc\.v1\.cri"|'io\.containerd\.grpc\.v1\.cri')\](.*?)(\n\s*\[|\z)`)
+	criPluginMatch := criPluginRegex.FindStringSubmatch(configContent)
+	if len(criPluginMatch) > 2 {
+		criPluginContent := criPluginMatch[2]
+		sandboxImage := extractString(criPluginContent, "sandbox_image")
+
+		// [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+		runcOptionsRegex := regexp.MustCompile(`(?s)\[plugins\.("io\.containerd\.grpc\.v1\.cri"|'io\.containerd\.grpc\.v1\.cri')\.containerd\.runtimes\.runc\.options\](.*?)(\n\s*\[|\z)`)
+		runcOptionsMatch := runcOptionsRegex.FindStringSubmatch(configContent) // Search in full config for this specific nested table
+		var systemdCgroup *bool
+		if len(runcOptionsMatch) > 2 {
+			systemdCgroup = extractBool(runcOptionsMatch[2], "SystemdCgroup")
+		}
+
+		// Simplified representation for PluginConfigs for these specific values
+		if sandboxImage != nil || systemdCgroup != nil {
+			if opts.PluginConfigs == nil {
+				opts.PluginConfigs = make(map[string]interface{})
+			}
+			criPlugins, ok := opts.PluginConfigs["io.containerd.grpc.v1.cri"].(map[string]interface{})
+			if !ok {
+				criPlugins = make(map[string]interface{})
+				opts.PluginConfigs["io.containerd.grpc.v1.cri"] = criPlugins
+			}
+			if sandboxImage != nil {
+				criPlugins["sandbox_image"] = *sandboxImage
+			}
+
+			if systemdCgroup != nil {
+				containerdPlugins, okC := criPlugins["containerd"].(map[string]interface{})
+				if !okC {
+					containerdPlugins = make(map[string]interface{})
+					criPlugins["containerd"] = containerdPlugins
+				}
+				runtimesPlugins, okR := containerdPlugins["runtimes"].(map[string]interface{})
+				if !okR {
+					runtimesPlugins = make(map[string]interface{})
+					containerdPlugins["runtimes"] = runtimesPlugins
+				}
+				runcPlugin, okRN := runtimesPlugins["runc"].(map[string]interface{})
+				if !okRN {
+					runcPlugin = make(map[string]interface{})
+					runtimesPlugins["runc"] = runcPlugin
+				}
+				runcOptions, okRO := runcPlugin["options"].(map[string]interface{})
+				if !okRO {
+					runcOptions = make(map[string]interface{})
+					runcPlugin["options"] = runcOptions
+				}
+				runcOptions["SystemdCgroup"] = *systemdCgroup
+			}
+		}
+	}
+	// Note: Parsing registry mirrors is complex with regex, not attempted here.
+	// ConfigureContainerd handles adding them by appending.
+
+	return opts, nil
+}
+
+// EnsureDefaultContainerdConfig ensures that a default containerd configuration exists and is applied.
+// It creates a default config.toml if one doesn't exist or is empty.
+func (r *defaultRunner) EnsureDefaultContainerdConfig(ctx context.Context, conn connector.Connector, facts *Facts) error {
+	if conn == nil {
+		return errors.New("connector cannot be nil for EnsureDefaultContainerdConfig")
+	}
+
+	exists, err := r.Exists(ctx, conn, containerdConfigPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check existence of %s", containerdConfigPath)
+	}
+
+	createDefaults := false
+	if !exists {
+		createDefaults = true
+	} else {
+		content, errRead := r.ReadFile(ctx, conn, containerdConfigPath)
+		if errRead != nil {
+			return errors.Wrapf(errRead, "failed to read existing %s to check if empty", containerdConfigPath)
+		}
+		trimmedContent := strings.TrimSpace(string(content))
+		// Consider config empty if it's empty, just "version = 2", or just comments.
+		// A more sophisticated check might involve trying to parse it lightly.
+		if len(trimmedContent) == 0 || trimmedContent == "{}" || trimmedContent == "version = 2" {
+			createDefaults = true
+		} else {
+			// If file exists and has some content, check if CRI plugin is configured.
+			// This is a heuristic. A proper TOML parser would be better.
+			if !strings.Contains(trimmedContent, "[plugins.\"io.containerd.grpc.v1.cri\"]") {
+				// If CRI is not explicitly configured, we might still want to ensure our defaults.
+				// However, overwriting a user's partial config is risky.
+				// For now, if there's content but no CRI, we'll assume user knows what they're doing,
+				// or they will use ConfigureContainerd for specific changes.
+				// Alternative: append default CRI if missing.
+				// For this function, "EnsureDefault" implies creating if absent or truly minimal.
+				// So, if it has substantial content, we don't overwrite with this function.
+			}
+		}
+	}
+
+	if createDefaults {
+		// Default configuration content.
+		// Enables CRI plugin, sets up basic sandbox image, and common plugin settings.
+		// SystemdCgroup is typically preferred on modern Linux systems.
+		defaultConfigContent := `version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = -999
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = "" # No debug socket by default
+  level = "info"
+
+[metrics]
+  address = "" # No metrics endpoint by default
+  grpc_histogram = false
+
+[cgroup]
+  path = "" # Let containerd detect
+
+# Plugins section
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.9" # Or appropriate version
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      snapshotter = "overlayfs" # Common default, ensure kernel support
+      default_runtime_name = "runc"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+        runtime_type = "io.containerd.runc.v2"
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+          SystemdCgroup = true # Set to true if systemd is the cgroup driver
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      # max_conf_num = 1 # Max number of CNI config files to load
+      # conf_template = "" # Path to CNI config template
+  # Minimal registry configuration. Mirrors can be added via ConfigureContainerd.
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+        endpoint = ["https://registry-1.docker.io"]
+`
+		// Adjust SystemdCgroup based on facts if possible
+		// This is a simple string replacement. A real TOML library would be better.
+		if facts != nil && facts.InitSystem != nil && facts.InitSystem.Type == InitSystemSystemd {
+			// Already set to true in the template above.
+			// If it were false by default:
+			// defaultConfigContent = strings.Replace(defaultConfigContent, "SystemdCgroup = false", "SystemdCgroup = true", 1)
+		} else {
+			// If not systemd, it should be false.
+			defaultConfigContent = strings.Replace(defaultConfigContent, "SystemdCgroup = true", "SystemdCgroup = false", 1)
+		}
+
+
+		if errMkdir := r.Mkdirp(ctx, conn, filepath.Dir(containerdConfigPath), "0755", true); errMkdir != nil {
+			return errors.Wrapf(errMkdir, "failed to create directory for %s", containerdConfigPath)
+		}
+		if errWrite := r.WriteFile(ctx, conn, []byte(defaultConfigContent), containerdConfigPath, "0644", true); errWrite != nil {
+			return errors.Wrapf(errWrite, "failed to write default containerd config to %s", containerdConfigPath)
+		}
+
+		// Restart containerd service
+		if facts == nil { // Gather facts if not provided, for service restart
+			var errFacts error
+			facts, errFacts = r.GatherFacts(ctx, conn)
+			if errFacts != nil {
+				return errors.Wrap(errFacts, "failed to gather facts for restarting containerd service after ensuring default config")
+			}
+		}
+		if errRestart := r.RestartService(ctx, conn, facts, "containerd"); errRestart != nil {
+			// Try common alternative name like containerd.service
+			errRestartAlt := r.RestartService(ctx, conn, facts, "containerd.service")
+			if errRestartAlt != nil {
+				return errors.Wrapf(errRestart, "failed to restart containerd (tried 'containerd', 'containerd.service') after writing default config. Original error: %v", errRestartAlt)
+			}
+		}
+	}
+	return nil
 }
 
 // ConfigureContainerd modifies containerd's config.toml.
-// Simplified: focuses on appending registry mirror configurations. Robust TOML editing is complex.
+// This is a best-effort modification due to lack of a full TOML parser.
+// It focuses on setting simple top-level values and appending registry mirrors.
+// More complex structural changes to the TOML are not reliably supported.
 func (r *defaultRunner) ConfigureContainerd(ctx context.Context, conn connector.Connector, opts ContainerdConfigOptions, restartService bool) error {
-	if conn == nil { return errors.New("connector cannot be nil") }
+	if conn == nil { return errors.New("connector cannot be nil for ConfigureContainerd") }
 
 	if err := r.Mkdirp(ctx, conn, filepath.Dir(containerdConfigPath), "0755", true); err != nil {
 		return errors.Wrapf(err, "failed to create dir for %s", containerdConfigPath)
 	}
 
-	var tomlSnippets []string
-	if opts.RegistryMirrors != nil {
+	currentContentBytes, err := r.ReadFile(ctx, conn, containerdConfigPath)
+	if err != nil {
+		exists, _ := r.Exists(ctx, conn, containerdConfigPath)
+		if exists { // File exists but couldn't read it
+			return errors.Wrapf(err, "failed to read existing containerd config at %s", containerdConfigPath)
+		}
+		currentContentBytes = []byte{} // Treat as empty if not found
+	}
+	currentContent := string(currentContentBytes)
+	lines := strings.Split(currentContent, "\n")
+	newLines := make([]string, 0, len(lines)+20) // Preallocate some space
+
+	modified := false
+
+	// Helper to replace or append a simple key-value line: key = value
+	// sectionHeader is like "[grpc]" or `[plugins."io.containerd.grpc.v1.cri"]` (can be empty for top-level)
+	// key is the actual key name, e.g., "address" or "sandbox_image"
+	// value can be string (will be quoted), int, or bool
+	replaceOrAppendValue := func(currentLines []string, sectionHeader, key string, value interface{}) ([]string, bool) {
+		var valueStr string
+		switch v := value.(type) {
+		case string:
+			valueStr = fmt.Sprintf("%q", v)
+		case *string:
+			if v == nil { return currentLines, false }
+			valueStr = fmt.Sprintf("%q", *v)
+		case int:
+			valueStr = strconv.Itoa(v)
+		case *int:
+			if v == nil { return currentLines, false }
+			valueStr = strconv.Itoa(*v)
+		case bool:
+			valueStr = strconv.FormatBool(v)
+		case *bool:
+			if v == nil { return currentLines, false }
+			valueStr = strconv.FormatBool(*v)
+		default:
+			return currentLines, false // Unsupported type
+		}
+
+		linePattern := regexp.MustCompile(fmt.Sprintf(`^\s*%s\s*=\s*.*`, regexp.QuoteMeta(key)))
+		newLine := fmt.Sprintf("%s = %s", key, valueStr)
+
+		var inSection bool
+		var addedOrReplaced bool
+		resultLines := make([]string, 0, len(currentLines)+1)
+
+		if sectionHeader == "" { // Top-level
+			inSection = true
+		}
+
+		for _, line := range currentLines {
+			trimmedLine := strings.TrimSpace(line)
+			if sectionHeader != "" && strings.HasPrefix(trimmedLine, sectionHeader) {
+				inSection = true
+				resultLines = append(resultLines, line)
+				continue
+			}
+			// If we encounter another section header, the current section ends
+			if sectionHeader != "" && inSection && strings.HasPrefix(trimmedLine, "[") && !strings.HasPrefix(trimmedLine, sectionHeader) {
+				if !addedOrReplaced { // Append before the new section if not found in the target section
+					resultLines = append(resultLines, newLine)
+					addedOrReplaced = true
+				}
+				inSection = false
+			}
+
+			if inSection && linePattern.MatchString(line) {
+				originalLineContent := strings.TrimSpace(line)
+				newLineWithIndent := line[:len(line)-len(originalLineContent)] + newLine // Preserve original indent
+				resultLines = append(resultLines, newLineWithIndent)
+				addedOrReplaced = true
+			} else {
+				resultLines = append(resultLines, line)
+			}
+		}
+		if !addedOrReplaced { // If not found anywhere (or section not found), append at the end (or create section and append)
+			if sectionHeader != "" && !strings.Contains(strings.Join(resultLines,"\n"), sectionHeader) {
+				resultLines = append(resultLines, "", sectionHeader) // Add section header
+			}
+			resultLines = append(resultLines, newLine)
+			addedOrReplaced = true
+		}
+		return resultLines, addedOrReplaced
+	}
+
+	// Apply top-level config changes
+	if opts.Root != nil { lines, modified = replaceOrAppendValue(lines, "", "root", opts.Root); modified = true }
+	if opts.State != nil { lines, modified = replaceOrAppendValue(lines, "", "state", opts.State); modified = true }
+	if opts.OOMScore != nil { lines, modified = replaceOrAppendValue(lines, "", "oom_score", opts.OOMScore); modified = true }
+	if opts.Version != nil { lines, modified = replaceOrAppendValue(lines, "", "version", opts.Version); modified = true}
+
+
+	// Apply [grpc] config changes
+	if opts.GRPC != nil {
+		if opts.GRPC.Address != nil { lines, modified = replaceOrAppendValue(lines, "[grpc]", "address", opts.GRPC.Address); modified = true }
+		if opts.GRPC.UID != nil { lines, modified = replaceOrAppendValue(lines, "[grpc]", "uid", opts.GRPC.UID); modified = true }
+		if opts.GRPC.GID != nil { lines, modified = replaceOrAppendValue(lines, "[grpc]", "gid", opts.GRPC.GID); modified = true }
+	}
+
+	// Apply specific plugin values if present in opts.PluginConfigs (very simplified)
+	if criPluginMap, ok := opts.PluginConfigs["io.containerd.grpc.v1.cri"].(map[string]interface{}); ok {
+		if sandboxImage, ok := criPluginMap["sandbox_image"].(string); ok {
+			lines, modified = replaceOrAppendValue(lines, `[plugins."io.containerd.grpc.v1.cri"]`, "sandbox_image", sandboxImage); modified = true
+		}
+		if containerdMap, ok := criPluginMap["containerd"].(map[string]interface{}); ok {
+			if runtimesMap, ok := containerdMap["runtimes"].(map[string]interface{}); ok {
+				if runcMap, ok := runtimesMap["runc"].(map[string]interface{}); ok {
+					if optionsMap, ok := runcMap["options"].(map[string]interface{}); ok {
+						if systemdCgroup, ok := optionsMap["SystemdCgroup"].(bool); ok {
+							lines, modified = replaceOrAppendValue(lines, `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]`, "SystemdCgroup", systemdCgroup); modified = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+
+	// Handle Registry Mirrors (primarily by appending, as robust merging is hard)
+	// We will ensure the main registry section exists, then append mirror blocks.
+	// This part remains similar to before, focusing on append for safety.
+	var mirrorSnippets []string
+	if opts.RegistryMirrors != nil && len(opts.RegistryMirrors) > 0 {
+		registrySectionHeader := `[plugins."io.containerd.grpc.v1.cri".registry]`
+		registryMirrorsHeader := `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]`
+
+		// Ensure registry and mirrors parent sections exist or are added
+		currentFullContent := strings.Join(lines, "\n")
+		if !strings.Contains(currentFullContent, registrySectionHeader) {
+			lines = append(lines, "", registrySectionHeader)
+			modified = true
+		}
+		if !strings.Contains(currentFullContent, registryMirrorsHeader) {
+			// Find where to insert registryMirrorsHeader: after registrySectionHeader
+			tempLines := make([]string, 0, len(lines)+1)
+			inserted := false
+			for _, line := range lines {
+				tempLines = append(tempLines, line)
+				if strings.TrimSpace(line) == registrySectionHeader && !inserted {
+					tempLines = append(tempLines, registryMirrorsHeader)
+					inserted = true
+					modified = true
+				}
+			}
+			if !inserted { // if registrySectionHeader was just added at the end
+				tempLines = append(tempLines, registryMirrorsHeader)
+				modified = true
+			}
+			lines = tempLines
+		}
+
+		currentFullContent = strings.Join(lines, "\n") // Update currentFullContent after potential additions
+
 		for registry, endpoints := range opts.RegistryMirrors {
 			if len(endpoints) > 0 {
 				escapedEndpoints := make([]string, len(endpoints))
 				for i, ep := range endpoints { escapedEndpoints[i] = fmt.Sprintf("%q", ep) }
-				// This TOML structure for mirrors is common:
-				// [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-				//   endpoint = ["https://mirror.example.com"]
-				snippet := fmt.Sprintf("\n[plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"%s\"]\n  endpoint = [%s]",
-					registry, strings.Join(escapedEndpoints, ", "))
-				tomlSnippets = append(tomlSnippets, snippet)
+
+				mirrorBlockHeader := fmt.Sprintf(`[plugins."io.containerd.grpc.v1.cri".registry.mirrors."%s"]`, registry)
+				mirrorBlockContent := fmt.Sprintf("  endpoint = [%s]", strings.Join(escapedEndpoints, ", "))
+
+				// Check if this specific mirror block already exists
+				if strings.Contains(currentFullContent, mirrorBlockHeader) {
+					// Simple strategy: remove old block and append new one.
+					// This is safer than trying to replace lines within a multi-line block with regex.
+					// This part is complex to do robustly with line-by-line processing.
+					// For now, we'll stick to appending if not exactly present, or let user manage duplicates.
+					// A more robust solution would be to parse TOML.
+					// Let's assume for now if the header exists, we don't re-add to avoid many duplicates.
+					// TODO: Improve this to replace existing mirror blocks if opting for full management.
+					// For now, if the mirror for `registry` already exists, we skip adding it again to avoid simple duplicates.
+					// This means it won't *update* existing mirror endpoints for a given registry, only add new ones.
+					if !strings.Contains(currentFullContent, fmt.Sprintf("%s\n%s", mirrorBlockHeader, mirrorBlockContent)) &&
+					   !strings.Contains(currentFullContent, fmt.Sprintf("%s\r\n%s", mirrorBlockHeader, mirrorBlockContent)) { // also check windows newlines
+						// If the exact content isn't there, append. This is still not perfect.
+						mirrorSnippets = append(mirrorSnippets, "", mirrorBlockHeader, mirrorBlockContent)
+						modified = true
+					}
+				} else {
+					mirrorSnippets = append(mirrorSnippets, "", mirrorBlockHeader, mirrorBlockContent)
+					modified = true
+				}
 			}
 		}
 	}
-	// Add more options here if they can be simply appended or set with basic TOML syntax.
-	// e.g. top-level string/int/bool values. Nested tables are harder.
 
-	if len(tomlSnippets) > 0 {
-		// This is a very basic append. A proper implementation would parse existing TOML, merge, and rewrite.
-		// For now, we'll append. This might lead to issues if sections are duplicated or malformed.
-		// It's better to ensure the config file is managed by a template or a single writer if using this method.
+	if len(mirrorSnippets) > 0 {
+		// Find where to append these snippets: inside the [plugins."io.containerd.grpc.v1.cri".registry.mirrors] block
+		// This is tricky. Simplest is to append at the end of the file if the section exists.
+		finalLines := make([]string, 0, len(lines)+len(mirrorSnippets))
+		registryMirrorsBlockEnd := false
+		appendedSnippets := false
 
-		// Create a command to append the snippets.
-		// This avoids reading/writing the file directly from here if complex merge is too hard.
-		// `echo "snippet" | sudo tee -a /etc/containerd/config.toml`
-		// However, `WriteFile` with append mode is not directly available.
-		// So, read, append string, write back.
+		// Try to append snippets at the end of the registry.mirrors section
+		// This assumes registry.mirrors is the last sub-table in registry, which is common
+		// but not guaranteed by TOML spec.
+		// A safer bet is just appending to the end of the file if the headers were ensured.
+		lines = append(lines, mirrorSnippets...)
+		// Note: this simple append might place them outside the intended section if other sections follow.
+		// The previous logic tries to ensure the parent headers.
+		modified = true // If we have snippets, something was modified or added.
+	}
 
-		currentContent, err := r.ReadFile(ctx, conn, containerdConfigPath)
-		if err != nil {
-			// If file doesn't exist, that's fine, we'll create it.
-			// But other read errors are problematic.
-			exists, _ := r.Exists(ctx, conn, containerdConfigPath)
-			if exists { // File exists but couldn't read it
-				return errors.Wrapf(err, "failed to read existing containerd config at %s", containerdConfigPath)
-			}
-			currentContent = []byte{} // Treat as empty
+	if modified {
+		finalConfigContent := strings.Join(lines, "\n")
+		// Add a final newline if missing
+		if !strings.HasSuffix(finalConfigContent, "\n") && finalConfigContent != "" {
+			finalConfigContent += "\n"
 		}
 
-		newContentStr := string(currentContent)
-		if len(newContentStr) > 0 && !strings.HasSuffix(newContentStr, "\n") {
-			newContentStr += "\n"
-		}
-		newContentStr += strings.Join(tomlSnippets, "\n") + "\n"
-
-		if err := r.WriteFile(ctx, conn, []byte(newContentStr), containerdConfigPath, "0644", true); err != nil {
+		if err := r.WriteFile(ctx, conn, []byte(finalConfigContent), containerdConfigPath, "0644", true); err != nil {
 			return errors.Wrapf(err, "failed to write updated containerd config to %s", containerdConfigPath)
 		}
 	}
 
-	if restartService {
-		facts, errFacts := r.GatherFacts(ctx, conn)
-		if errFacts != nil { return errors.Wrap(errFacts, "failed to gather facts for containerd restart") }
+	if modified && restartService {
+		var currentFacts *Facts = facts // Use provided facts if available
+		if currentFacts == nil {
+			var errFacts error
+			currentFacts, errFacts = r.GatherFacts(ctx, conn)
+			if errFacts != nil {
+				return errors.Wrap(errFacts, "failed to gather facts for containerd restart")
+			}
+		}
 
-		errRestart := r.RestartService(ctx, conn, facts, "containerd")
+		errRestart := r.RestartService(ctx, conn, currentFacts, "containerd")
 		if errRestart != nil {
-			// Try common alternative name like containerd.service
-			errRestartAlt := r.RestartService(ctx, conn, facts, "containerd.service")
+			errRestartAlt := r.RestartService(ctx, conn, currentFacts, "containerd.service")
 			if errRestartAlt != nil {
-				return errors.Wrapf(errRestart, "failed to restart containerd (tried 'containerd', 'containerd.service'). Original error: %v", errRestartAlt)
+				return errors.Wrapf(errRestart, "failed to restart containerd (tried 'containerd', 'containerd.service') after configuration. Original error: %v", errRestartAlt)
 			}
 		}
 	}
@@ -544,82 +1066,507 @@ func (r *defaultRunner) CrictlListPods(ctx context.Context, conn connector.Conne
 	return result.Pods, nil
 }
 
+// CrictlRunPodSandbox runs a pod sandbox.
+// Corresponds to `crictl runp [--runtime <runtime>] <pod-config.json>`.
+func (r *defaultRunner) CrictlRunPodSandbox(ctx context.Context, conn connector.Connector, podSandboxConfigFile string, runtimeHandler string) (string, error) {
+	if conn == nil { return "", errors.New("connector cannot be nil for CrictlRunPodSandbox") }
+	if podSandboxConfigFile == "" { return "", errors.New("podSandboxConfigFile is required for CrictlRunPodSandbox") }
 
-func (r *defaultRunner) CrictlRunPod(ctx context.Context, conn connector.Connector, podSandboxConfigFile string) (string, error) {
-	if conn == nil { return "", errors.New("connector cannot be nil") }
-	if podSandboxConfigFile == "" { return "", errors.New("podSandboxConfigFile is required") }
-
-	// Ensure the config file exists
 	exists, err := r.Exists(ctx, conn, podSandboxConfigFile)
-	if err != nil { return "", errors.Wrapf(err, "failed to check existence of %s", podSandboxConfigFile) }
+	if err != nil { return "", errors.Wrapf(err, "failed to check existence of pod sandbox config %s", podSandboxConfigFile) }
 	if !exists { return "", errors.Errorf("pod sandbox config file %s does not exist", podSandboxConfigFile) }
 
-	cmd := fmt.Sprintf("crictl runp %s", shellEscape(podSandboxConfigFile))
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "runp")
+	if strings.TrimSpace(runtimeHandler) != "" {
+		cmdArgs = append(cmdArgs, "--runtime", shellEscape(runtimeHandler))
+	}
+	cmdArgs = append(cmdArgs, shellEscape(podSandboxConfigFile))
+
+	cmd := strings.Join(cmdArgs, " ")
 	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
 	if err != nil {
 		return "", errors.Wrapf(err, "crictl runp failed. Stderr: %s", string(stderr))
 	}
-	// crictl runp outputs the Pod ID on success
 	return strings.TrimSpace(string(stdout)), nil
 }
 
-func (r *defaultRunner) CrictlStopPod(ctx context.Context, conn connector.Connector, podID string) error {
-	if conn == nil { return errors.New("connector cannot be nil") }
-	if podID == "" { return errors.New("podID is required") }
+// CrictlStopPodSandbox stops a running pod sandbox.
+// Corresponds to `crictl stopp <pod-id>`.
+func (r *defaultRunner) CrictlStopPodSandbox(ctx context.Context, conn connector.Connector, podID string) error {
+	if conn == nil { return errors.New("connector cannot be nil for CrictlStopPodSandbox") }
+	if podID == "" { return errors.New("podID is required for CrictlStopPodSandbox") }
+
 	cmd := fmt.Sprintf("crictl stopp %s", shellEscape(podID))
 	_, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
 	if err != nil {
-		if strings.Contains(string(stderr), "not found") { return nil } // Idempotency
+		// Idempotency: if already stopped or not found, crictl might return error but it's effectively stopped.
+		// crictl stopp specific errors:
+		// - "pod sandbox ... not found": This means it's already gone or never existed.
+		// - If it was already stopped, it might return success or a specific message.
+		// For simplicity, we consider "not found" as success for idempotency.
+		if strings.Contains(string(stderr), "not found") {
+			return nil
+		}
 		return errors.Wrapf(err, "crictl stopp %s failed. Stderr: %s", podID, string(stderr))
 	}
 	return nil
 }
 
-func (r *defaultRunner) CrictlRemovePod(ctx context.Context, conn connector.Connector, podID string) error {
-	if conn == nil { return errors.New("connector cannot be nil") }
-	if podID == "" { return errors.New("podID is required") }
+// CrictlRemovePodSandbox removes a pod sandbox.
+// Corresponds to `crictl rmp <pod-id>`.
+func (r *defaultRunner) CrictlRemovePodSandbox(ctx context.Context, conn connector.Connector, podID string) error {
+	if conn == nil { return errors.New("connector cannot be nil for CrictlRemovePodSandbox") }
+	if podID == "" { return errors.New("podID is required for CrictlRemovePodSandbox") }
+
 	cmd := fmt.Sprintf("crictl rmp %s", shellEscape(podID))
 	_, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
 	if err != nil {
-		if strings.Contains(string(stderr), "not found") { return nil } // Idempotency
+		if strings.Contains(string(stderr), "not found") { // Idempotency
+			return nil
+		}
 		return errors.Wrapf(err, "crictl rmp %s failed. Stderr: %s", podID, string(stderr))
 	}
 	return nil
 }
 
-// Remaining crictl functions are still placeholders
+// CrictlInspectPod retrieves information about a specific pod sandbox.
+// Corresponds to `crictl inspectp <pod-id> -o json`.
 func (r *defaultRunner) CrictlInspectPod(ctx context.Context, conn connector.Connector, podID string) (*CrictlPodDetails, error) {
-	return nil, errors.New("not implemented: CrictlInspectPod")
-}
-func (r *defaultRunner) CrictlCreateContainer(ctx context.Context, conn connector.Connector, podID string, containerConfigFile string, podSandboxConfigFile string) (string, error) {
-	return "", errors.New("not implemented: CrictlCreateContainer")
-}
-func (r *defaultRunner) CrictlStartContainer(ctx context.Context, conn connector.Connector, containerID string) error {
-	return errors.New("not implemented: CrictlStartContainer")
-}
-func (r *defaultRunner) CrictlStopContainer(ctx context.Context, conn connector.Connector, containerID string, timeout int64) error {
-	return errors.New("not implemented: CrictlStopContainer")
-}
-func (r *defaultRunner) CrictlRemoveContainerForce(ctx context.Context, conn connector.Connector, containerID string) error {
-	return errors.New("not implemented: CrictlRemoveContainerForce")
-}
-func (r *defaultRunner) CrictlInspectContainer(ctx context.Context, conn connector.Connector, containerID string) (*CrictlContainerDetails, error) {
-	return nil, errors.New("not implemented: CrictlInspectContainer")
-}
-func (r *defaultRunner) CrictlLogs(ctx context.Context, conn connector.Connector, containerID string, opts CrictlLogOptions) (string, error) {
-	return "", errors.New("not implemented: CrictlLogs")
-}
-func (r *defaultRunner) CrictlExec(ctx context.Context, conn connector.Connector, containerID string, timeout time.Duration, sync bool, cmd []string) (string, error) {
-	return "", errors.New("not implemented: CrictlExec")
-}
-func (r *defaultRunner) CrictlPortForward(ctx context.Context, conn connector.Connector, podID string, ports []string) (string, error) {
-	return "", errors.New("not implemented: CrictlPortForward")
-}
-func (r *defaultRunner) CrictlVersion(ctx context.Context, conn connector.Connector) (*CrictlVersionInfo, error) {
-	return nil, errors.New("not implemented: CrictlVersion")
-}
-func (r *defaultRunner) CrictlRuntimeConfig(ctx context.Context, conn connector.Connector) (string, error) {
-	return "", errors.New("not implemented: CrictlRuntimeConfig")
+	if conn == nil { return nil, errors.New("connector cannot be nil for CrictlInspectPod") }
+	if podID == "" { return nil, errors.New("podID is required for CrictlInspectPod") }
+
+	cmd := fmt.Sprintf("crictl inspectp %s -o json", shellEscape(podID))
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		if strings.Contains(string(stderr), "not found") {
+			return nil, nil // Return nil, nil if pod not found, consistent with Docker inspect behavior
+		}
+		return nil, errors.Wrapf(err, "crictl inspectp %s failed. Stderr: %s", podID, string(stderr))
+	}
+
+	var details CrictlPodDetails
+	if err := json.Unmarshal(stdout, &details); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse crictl inspectp JSON for pod %s. Output: %s", podID, string(stdout))
+	}
+	return &details, nil
 }
 
-[end of pkg/runner/containerd.go]
+// CrictlPodSandboxStatus retrieves the status of a pod sandbox.
+// Note: `crictl inspectp` provides status. This can be a wrapper or alias.
+// For more detailed status, `crictl inspectp` is generally used.
+// `crictl ps -id <pod-id> -o json` could also provide basic status.
+func (r *defaultRunner) CrictlPodSandboxStatus(ctx context.Context, conn connector.Connector, podID string, verbose bool) (*CrictlPodDetails, error) {
+	// verbose flag can be used to decide if more info than just basic state is needed.
+	// CrictlInspectPod already gets all details.
+	if verbose {
+		return r.CrictlInspectPod(ctx, conn, podID)
+	}
+
+	// If not verbose, we might want a lighter query, but crictl inspectp is standard for details.
+	// Let's use inspectp and the caller can decide what to do with the CrictlPodDetails.
+	// Alternative for non-verbose: `crictl ps --id <ID> -o json` and parse its limited output.
+	// For now, stick to inspectp for consistency.
+	return r.CrictlInspectPod(ctx, conn, podID)
+}
+
+
+// CrictlCreateContainerInPod creates a container within an existing pod sandbox.
+// Corresponds to `crictl create <pod-id> <container-config.json> <pod-config.json>`.
+func (r *defaultRunner) CrictlCreateContainerInPod(ctx context.Context, conn connector.Connector, podID string, containerConfigFile string, podSandboxConfigFile string) (string, error) {
+	if conn == nil { return "", errors.New("connector cannot be nil for CrictlCreateContainerInPod") }
+	if podID == "" { return "", errors.New("podID is required for CrictlCreateContainerInPod") }
+	if containerConfigFile == "" { return "", errors.New("containerConfigFile is required for CrictlCreateContainerInPod") }
+	if podSandboxConfigFile == "" { return "", errors.New("podSandboxConfigFile is required for CrictlCreateContainerInPod") }
+
+	for _, p := range []string{containerConfigFile, podSandboxConfigFile} {
+		exists, err := r.Exists(ctx, conn, p)
+		if err != nil { return "", errors.Wrapf(err, "failed to check existence of config file %s", p) }
+		if !exists { return "", errors.Errorf("config file %s does not exist", p) }
+	}
+
+	cmd := fmt.Sprintf("crictl create %s %s %s",
+		shellEscape(podID),
+		shellEscape(containerConfigFile),
+		shellEscape(podSandboxConfigFile))
+
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		return "", errors.Wrapf(err, "crictl create container in pod %s failed. Stderr: %s", podID, string(stderr))
+	}
+	// crictl create outputs the Container ID on success
+	return strings.TrimSpace(string(stdout)), nil
+}
+
+// CrictlStartContainerInPod starts a created container within a pod.
+// Corresponds to `crictl start <container-id>`.
+func (r *defaultRunner) CrictlStartContainerInPod(ctx context.Context, conn connector.Connector, containerID string) error {
+	if conn == nil { return errors.New("connector cannot be nil for CrictlStartContainerInPod") }
+	if containerID == "" { return errors.New("containerID is required for CrictlStartContainerInPod") }
+
+	cmd := fmt.Sprintf("crictl start %s", shellEscape(containerID))
+	_, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		// crictl start can fail if already started.
+		// Example error: "FATA[0000] starting container "ID": ProcessUtility.StartProcess: function not implemented" (if runtime issue)
+		// Or "container ... is already running" - this should not be an error for idempotency.
+		// However, crictl start usually exits 0 if already running.
+		return errors.Wrapf(err, "crictl start %s failed. Stderr: %s", containerID, string(stderr))
+	}
+	return nil
+}
+
+// CrictlStopContainerInPod stops a running container in a pod.
+// Corresponds to `crictl stop [--timeout <sec>] <container-id>`.
+func (r *defaultRunner) CrictlStopContainerInPod(ctx context.Context, conn connector.Connector, containerID string, timeout int64) error {
+	if conn == nil { return errors.New("connector cannot be nil for CrictlStopContainerInPod") }
+	if containerID == "" { return errors.New("containerID is required for CrictlStopContainerInPod") }
+
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "stop")
+	if timeout >= 0 { // crictl default is 0 (no timeout, meaning it might wait indefinitely for graceful stop by runtime)
+		// However, a common k8s behavior is a specific grace period.
+		// If timeout is 0, it means stop immediately (kill).
+		// If timeout > 0, it's a grace period.
+		// crictl's --timeout flag: "Seconds to wait for stop before killing the container"
+		cmdArgs = append(cmdArgs, "--timeout", fmt.Sprintf("%d", timeout))
+	}
+	cmdArgs = append(cmdArgs, shellEscape(containerID))
+	cmd := strings.Join(cmdArgs, " ")
+
+	_, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout + time.Duration(timeout)*time.Second})
+	if err != nil {
+		if strings.Contains(string(stderr), "not found") || strings.Contains(string(stderr), "already stopped") || strings.Contains(string(stderr), "isn't running") {
+			return nil // Idempotency
+		}
+		return errors.Wrapf(err, "crictl stop %s failed. Stderr: %s", containerID, string(stderr))
+	}
+	return nil
+}
+
+// CrictlRemoveContainerInPod removes a container from a pod.
+// Corresponds to `crictl rm [-f] <container-id>`.
+func (r *defaultRunner) CrictlRemoveContainerInPod(ctx context.Context, conn connector.Connector, containerID string, force bool) error {
+	if conn == nil { return errors.New("connector cannot be nil for CrictlRemoveContainerInPod") }
+	if containerID == "" { return errors.New("containerID is required for CrictlRemoveContainerInPod") }
+
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "rm")
+	if force {
+		cmdArgs = append(cmdArgs, "-f") // or --force
+	}
+	cmdArgs = append(cmdArgs, shellEscape(containerID))
+	cmd := strings.Join(cmdArgs, " ")
+
+	_, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		if strings.Contains(string(stderr), "not found") {
+			return nil // Idempotency
+		}
+		return errors.Wrapf(err, "crictl rm %s failed. Stderr: %s", containerID, string(stderr))
+	}
+	return nil
+}
+
+// CrictlInspectContainerInPod retrieves information about a specific container in a pod.
+// Corresponds to `crictl inspect <container-id> -o json`.
+func (r *defaultRunner) CrictlInspectContainerInPod(ctx context.Context, conn connector.Connector, containerID string) (*CrictlContainerDetails, error) {
+	if conn == nil { return nil, errors.New("connector cannot be nil for CrictlInspectContainerInPod") }
+	if containerID == "" { return nil, errors.New("containerID is required for CrictlInspectContainerInPod") }
+
+	cmd := fmt.Sprintf("crictl inspect %s -o json", shellEscape(containerID))
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		if strings.Contains(string(stderr), "not found") {
+			return nil, nil // Return nil, nil if container not found
+		}
+		return nil, errors.Wrapf(err, "crictl inspect %s failed. Stderr: %s", containerID, string(stderr))
+	}
+
+	var details CrictlContainerDetails
+	if err := json.Unmarshal(stdout, &details); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse crictl inspect JSON for container %s. Output: %s", containerID, string(stdout))
+	}
+	return &details, nil
+}
+
+// CrictlContainerStatus retrieves the status of a container.
+// Similar to InspectContainerInPod, as `crictl inspect` provides status info.
+func (r *defaultRunner) CrictlContainerStatus(ctx context.Context, conn connector.Connector, containerID string, verbose bool) (*CrictlContainerDetails, error) {
+	// `crictl inspect` is the primary way to get detailed status.
+	// `crictl ps --id <ID> -o json` can provide a summary.
+	// For now, using inspect for both verbose and non-verbose, caller can extract needed info.
+	return r.CrictlInspectContainerInPod(ctx, conn, containerID)
+}
+
+
+// CrictlLogsForContainer retrieves logs for a specific container.
+// Corresponds to `crictl logs <container-id> [options]`.
+func (r *defaultRunner) CrictlLogsForContainer(ctx context.Context, conn connector.Connector, containerID string, opts CrictlLogOptions) (string, error) {
+	if conn == nil { return "", errors.New("connector cannot be nil for CrictlLogsForContainer") }
+	if containerID == "" { return "", errors.New("containerID is required for CrictlLogsForContainer") }
+
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "logs")
+	if opts.Follow { cmdArgs = append(cmdArgs, "-f") }
+	if opts.Timestamps { cmdArgs = append(cmdArgs, "--timestamps") }
+	if opts.Since != "" { cmdArgs = append(cmdArgs, "--since", shellEscape(opts.Since)) }
+	if opts.TailLines != nil && *opts.TailLines > 0 {
+		cmdArgs = append(cmdArgs, "--tail", fmt.Sprintf("%d", *opts.TailLines))
+	} else if opts.NumLines != nil && *opts.NumLines > 0 { // Support for older --lines
+		cmdArgs = append(cmdArgs, "--lines", fmt.Sprintf("%d", *opts.NumLines))
+	}
+	// No --latest in modern crictl, handled by tail or since.
+
+	cmdArgs = append(cmdArgs, shellEscape(containerID))
+	cmd := strings.Join(cmdArgs, " ")
+
+	// Timeout for logs can be longer, especially if not following.
+	// If following, the command might run for a long time, relying on context for cancellation.
+	logTimeout := DefaultCrictlTimeout
+	if opts.Follow { logTimeout = 10 * time.Minute } // Longer timeout for follow, but context should cancel.
+
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: logTimeout})
+	output := string(stdout) + string(stderr)
+	if err != nil {
+		// If context was cancelled and we were following, it's not a true error of the command.
+		if opts.Follow && ctx.Err() != nil {
+			return output, nil
+		}
+		return output, errors.Wrapf(err, "crictl logs for %s failed. Output: %s", containerID, output)
+	}
+	return string(stdout), nil // crictl logs sends logs to stdout
+}
+
+// CrictlExecInContainerSync executes a command synchronously inside a container.
+// Corresponds to `crictl exec -s <container-id> <cmd> [args...]`.
+func (r *defaultRunner) CrictlExecInContainerSync(ctx context.Context, conn connector.Connector, containerID string, timeout time.Duration, cmdToExec []string) (string, string, error) {
+	if conn == nil { return "", "", errors.New("connector cannot be nil for CrictlExecInContainerSync") }
+	if containerID == "" { return "", "", errors.New("containerID is required for CrictlExecInContainerSync") }
+	if len(cmdToExec) == 0 { return "", "", errors.New("command to exec is required") }
+
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "exec", "-s") // -s for sync
+	if timeout > 0 {
+		cmdArgs = append(cmdArgs, "--timeout", fmt.Sprintf("%ds", int(timeout.Seconds())))
+	}
+	cmdArgs = append(cmdArgs, shellEscape(containerID))
+	for _, arg := range cmdToExec {
+		cmdArgs = append(cmdArgs, shellEscape(arg))
+	}
+	cmd := strings.Join(cmdArgs, " ")
+
+	execCmdTimeout := DefaultCrictlTimeout // Default timeout for the crictl command itself
+	if timeout > 0 {
+		execCmdTimeout += timeout // Add the user-specified timeout to the command's own execution timeout
+	}
+
+
+	stdoutBytes, stderrBytes, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: execCmdTimeout})
+	stdout := string(stdoutBytes)
+	stderr := string(stderrBytes)
+
+	if err != nil {
+		// crictl exec returns non-zero exit code if the command in container fails.
+		// This is an error from the perspective of the Exec call.
+		return stdout, stderr, errors.Wrapf(err, "crictl exec sync in %s failed. Stdout: %s, Stderr: %s", containerID, stdout, stderr)
+	}
+	return stdout, stderr, nil
+}
+
+// CrictlExecInContainerAsync executes a command asynchronously. Placeholder.
+func (r *defaultRunner) CrictlExecInContainerAsync(ctx context.Context, conn connector.Connector, containerID string, cmdToExec []string) (string, error) {
+	return "", errors.New("not implemented: CrictlExecInContainerAsync (crictl does not have a direct async exec that returns a request ID; typically uses attach for async-like behavior)")
+}
+
+
+// CrictlPortForward forwards ports from the host to a pod. Placeholder.
+func (r *defaultRunner) CrictlPortForward(ctx context.Context, conn connector.Connector, podID string, ports []string) (string, error) {
+	// crictl port-forward <pod-id> [port:port ...]
+	// This command is typically long-running.
+	if conn == nil { return "", errors.New("connector cannot be nil for CrictlPortForward") }
+	if podID == "" { return "", errors.New("podID is required for CrictlPortForward") }
+	if len(ports) == 0 { return "", errors.New("at least one port mapping is required for CrictlPortForward") }
+
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "port-forward", shellEscape(podID))
+	for _, p := range ports {
+		cmdArgs = append(cmdArgs, shellEscape(p))
+	}
+	cmd := strings.Join(cmdArgs, " ")
+
+	// This is tricky. port-forward blocks. How do we handle this?
+	// Option 1: Run in background and return. Caller needs to manage.
+	// Option 2: This runner function blocks. Not ideal for automation.
+	// Option 3: Return an error saying it's not suitable for this type of runner.
+	// For now, let's assume it's a command we can run and get output from, even if it's just help text or an error.
+	// A true port-forwarding solution would need more sophisticated handling (background process, cancellation).
+	// Let's try to run it with a timeout. If it doesn't error out immediately, it means it's trying to forward.
+	// We'll return the stdout (which might be empty if successful and blocking).
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: 10 * time.Second}) // Short timeout
+	if err != nil {
+		// If timeout, it means it was likely trying to run.
+		if ctx.Err() == context.DeadlineExceeded {
+			return string(stdout), errors.New("CrictlPortForward started but command is long-running; actual forwarding not guaranteed by this call")
+		}
+		return string(stdout) + string(stderr), errors.Wrapf(err, "crictl port-forward for pod %s failed. Stderr: %s", podID, string(stderr))
+	}
+	return string(stdout), nil // If it returns quickly without error, it might be help text or an issue.
+}
+
+// CrictlVersion retrieves crictl and runtime version information.
+// Corresponds to `crictl version -o json`.
+func (r *defaultRunner) CrictlVersion(ctx context.Context, conn connector.Connector) (*CrictlVersionInfo, error) {
+	if conn == nil { return nil, errors.New("connector cannot be nil for CrictlVersion") }
+
+	cmd := "crictl version -o json"
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		return nil, errors.Wrapf(err, "crictl version failed. Stderr: %s", string(stderr))
+	}
+
+	var versionInfo CrictlVersionInfo
+	if err := json.Unmarshal(stdout, &versionInfo); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse crictl version JSON. Output: %s", string(stdout))
+	}
+	return &versionInfo, nil
+}
+
+// CrictlInfo retrieves information about the CRI runtime.
+// Corresponds to `crictl info -o json`.
+func (r *defaultRunner) CrictlInfo(ctx context.Context, conn connector.Connector) (*CrictlRuntimeInfo, error) {
+	if conn == nil { return nil, errors.New("connector cannot be nil for CrictlInfo") }
+
+	cmd := "crictl info -o json"
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		return nil, errors.Wrapf(err, "crictl info failed. Stderr: %s", string(stderr))
+	}
+	var runtimeInfo CrictlRuntimeInfo
+	if err := json.Unmarshal(stdout, &runtimeInfo); err != nil {
+		// crictl info -o json can sometimes produce invalid JSON if some fields are missing or malformed by the runtime.
+		// Try to be a bit resilient if the main parts are there.
+		// However, a strict parse is usually better.
+		return nil, errors.Wrapf(err, "failed to parse crictl info JSON. Output: %s", string(stdout))
+	}
+	return &runtimeInfo, nil
+}
+
+
+// CrictlRuntimeConfig retrieves the runtime configuration.
+// Corresponds to `crictl runtime-config -o json` (though crictl runtime-config is more for testing specific handlers).
+// `crictl info` is generally what provides the runtime config details.
+// This might be a bit redundant with CrictlInfo.
+func (r *defaultRunner) CrictlRuntimeConfig(ctx context.Context, conn connector.Connector) (string, error) {
+	// `crictl info -o json` is likely what's intended here for general config.
+	// `crictl runtime-config` is for a specific runtime handler.
+	// Let's assume the user wants the output of `crictl info` as a string.
+	info, err := r.CrictlInfo(ctx, conn)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get runtime info for CrictlRuntimeConfig")
+	}
+	jsonBytes, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal runtime info to JSON for CrictlRuntimeConfig")
+	}
+	return string(jsonBytes), nil
+}
+
+// CrictlStats retrieves resource usage statistics for pods or containers.
+// `crictl stats [-o json] [<pod-id>|<container-id>]`
+func (r *defaultRunner) CrictlStats(ctx context.Context, conn connector.Connector, resourceID string, outputFormat string) (string, error) {
+	if conn == nil { return "", errors.New("connector cannot be nil for CrictlStats") }
+
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "stats")
+	if strings.TrimSpace(outputFormat) == "json" {
+		cmdArgs = append(cmdArgs, "-o", "json")
+	}
+	if strings.TrimSpace(resourceID) != "" {
+		cmdArgs = append(cmdArgs, shellEscape(resourceID))
+	}
+	// Note: crictl stats -o json output is a stream of JSON objects if resourceID is empty or for multiple items.
+	// If resourceID is given, it's a single JSON object (or stream if it's a pod and it has multiple containers).
+	// This function returning a single string is best for a single resource JSON output.
+	// For streaming or multiple objects, the parsing would be more complex.
+
+	cmd := strings.Join(cmdArgs, " ")
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		return string(stdout) + string(stderr), errors.Wrapf(err, "crictl stats for '%s' failed. Stderr: %s", resourceID, string(stderr))
+	}
+	return string(stdout), nil
+}
+
+
+// CrictlPodStats retrieves resource usage statistics for all containers in one or more pods.
+// `crictl ps -o json [--pod <pod-id>]`
+func (r *defaultRunner) CrictlPodStats(ctx context.Context, conn connector.Connector, outputFormat string, podID string) (string, error) {
+	if conn == nil { return "", errors.New("connector cannot be nil for CrictlPodStats") }
+
+	var cmdArgs []string
+	cmdArgs = append(cmdArgs, "crictl", "stats") // `crictl stats` is the command for this
+	if strings.TrimSpace(outputFormat) == "json" {
+		cmdArgs = append(cmdArgs, "-o", "json")
+	}
+	if strings.TrimSpace(podID) != "" {
+		cmdArgs = append(cmdArgs, shellEscape(podID)) // If podID is given, it filters stats for that pod.
+	}
+	// If podID is empty, it lists stats for all pods/containers.
+	// The JSON output structure can be complex (streaming JSON objects).
+	// This function expects to return a single string, so it's best if podID is specified and output is json.
+	cmd := strings.Join(cmdArgs, " ")
+
+	stdout, stderr, err := conn.Exec(ctx, cmd, &connector.ExecOptions{Sudo: true, Timeout: DefaultCrictlTimeout})
+	if err != nil {
+		return string(stdout) + string(stderr), errors.Wrapf(err, "crictl pod stats for '%s' failed. Stderr: %s", podID, string(stderr))
+	}
+	return string(stdout), nil
+}
+
+// EnsureDefaultCrictlConfig ensures that a default crictl configuration file exists.
+// It creates a default /etc/crictl.yaml if one doesn't exist or is empty.
+func (r *defaultRunner) EnsureDefaultCrictlConfig(ctx context.Context, conn connector.Connector) error {
+	if conn == nil {
+		return errors.New("connector cannot be nil for EnsureDefaultCrictlConfig")
+	}
+
+	exists, err := r.Exists(ctx, conn, crictlConfigPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check existence of %s", crictlConfigPath)
+	}
+
+	createDefaults := false
+	if !exists {
+		createDefaults = true
+	} else {
+		content, errRead := r.ReadFile(ctx, conn, crictlConfigPath)
+		if errRead != nil {
+			return errors.Wrapf(errRead, "failed to read existing %s to check if empty", crictlConfigPath)
+		}
+		trimmedContent := strings.TrimSpace(string(content))
+		if len(trimmedContent) == 0 || trimmedContent == "{}" { // Simple check for empty or empty JSON
+			createDefaults = true
+		}
+		// If there's some content, we assume it's user-managed unless it's clearly a placeholder.
+		// Unlike containerd's complex TOML, crictl.yaml is simpler.
+		// We could check if runtime-endpoint is missing, but for "EnsureDefault",
+		// creating if absent or truly minimal is the main goal.
+	}
+
+	if createDefaults {
+		// Default crictl.yaml content
+		// Points to the standard containerd socket.
+		defaultCrictlConfigContent := `runtime-endpoint: unix:///run/containerd/containerd.sock
+image-endpoint: unix:///run/containerd/containerd.sock
+timeout: 10 # seconds
+debug: false
+pull-image-on-create: false
+`
+		// The ConfigureCrictl method handles Mkdirp and WriteFile.
+		if err := r.ConfigureCrictl(ctx, conn, defaultCrictlConfigContent); err != nil {
+			return errors.Wrap(err, "failed to apply default crictl configuration")
+		}
+	}
+	return nil
+}

--- a/pkg/runner/docker.go
+++ b/pkg/runner/docker.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mensylisir/kubexm/pkg/connector"
-	"github.com/mensylisir/kubexm/pkg/utils"
+	"github.com/mensylisir/kubexm/pkg/util"
 )
 
 const (

--- a/pkg/runner/kubectl_test.go
+++ b/pkg/runner/kubectl_test.go
@@ -86,7 +86,9 @@ func TestDefaultRunner_KubectlExec(t *testing.T) {
 func TestDefaultRunner_KubectlGetNodes(t *testing.T) {
     ctrl := gomock.NewController(t); defer ctrl.Finish()
     mockConn := mocks.NewMockConnector(ctrl); runner := NewDefaultRunner(); ctx := context.Background()
-    sampleJSON := `{"items": [{"metadata": {"name": "node1"}}]}`, var expected []KubectlNodeInfo; json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlNodeInfo `json:"items"`}{Items: &expected})
+    sampleJSON := `{"items": [{"metadata": {"name": "node1"}}]}`
+	var expected []KubectlNodeInfo
+	json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlNodeInfo `json:"items"`}{Items: &expected})
     mockConn.EXPECT().Exec(ctx, "kubectl get nodes -o json", gomock.Any()).Return([]byte(sampleJSON), nil, nil).Times(1)
     nodes, err := runner.KubectlGetNodes(ctx, mockConn, KubectlGetOptions{}); assert.NoError(t, err); assert.Equal(t, expected, nodes)
 }
@@ -94,7 +96,9 @@ func TestDefaultRunner_KubectlGetNodes(t *testing.T) {
 func TestDefaultRunner_KubectlGetPods(t *testing.T) {
     ctrl := gomock.NewController(t); defer ctrl.Finish()
     mockConn := mocks.NewMockConnector(ctrl); runner := NewDefaultRunner(); ctx := context.Background(); ns := "appns"
-    sampleJSON := `{"items": [{"metadata": {"name": "poda"}}]}`, var expected []KubectlPodInfo; json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlPodInfo `json:"items"`}{Items: &expected})
+    sampleJSON := `{"items": [{"metadata": {"name": "poda"}}]}`
+	var expected []KubectlPodInfo
+	json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlPodInfo `json:"items"`}{Items: &expected})
     mockConn.EXPECT().Exec(ctx, fmt.Sprintf("kubectl get pods --namespace %s -o json", shellEscape(ns)), gomock.Any()).Return([]byte(sampleJSON), nil, nil).Times(1)
     pods, err := runner.KubectlGetPods(ctx, mockConn, ns, KubectlGetOptions{}); assert.NoError(t, err); assert.Equal(t, expected, pods)
 }
@@ -102,7 +106,9 @@ func TestDefaultRunner_KubectlGetPods(t *testing.T) {
 func TestDefaultRunner_KubectlGetServices(t *testing.T) {
 	ctrl := gomock.NewController(t); defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl); runner := NewDefaultRunner(); ctx := context.Background(); ns := "prod"
-	sampleJSON := `{"items": [{"metadata": {"name": "svca"}}]}`, var expected []KubectlServiceInfo; json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlServiceInfo `json:"items"`}{Items: &expected})
+	sampleJSON := `{"items": [{"metadata": {"name": "svca"}}]}`
+	var expected []KubectlServiceInfo
+	json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlServiceInfo `json:"items"`}{Items: &expected})
 	mockConn.EXPECT().Exec(ctx, fmt.Sprintf("kubectl get services --namespace %s -o json", shellEscape(ns)), gomock.Any()).Return([]byte(sampleJSON), nil, nil).Times(1)
 	svcs, err := runner.KubectlGetServices(ctx, mockConn, ns, KubectlGetOptions{}); assert.NoError(t, err); assert.Equal(t, expected, svcs)
 }
@@ -110,7 +116,9 @@ func TestDefaultRunner_KubectlGetServices(t *testing.T) {
 func TestDefaultRunner_KubectlGetDeployments(t *testing.T) {
 	ctrl := gomock.NewController(t); defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl); runner := NewDefaultRunner(); ctx := context.Background(); ns := "dev"
-	sampleJSON := `{"items": [{"metadata": {"name": "depx"}}]}`, var expected []KubectlDeploymentInfo; json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlDeploymentInfo `json:"items"`}{Items: &expected})
+	sampleJSON := `{"items": [{"metadata": {"name": "depx"}}]}`
+	var expected []KubectlDeploymentInfo
+	json.Unmarshal([]byte(sampleJSON), &struct{Items []KubectlDeploymentInfo `json:"items"`}{Items: &expected})
 	mockConn.EXPECT().Exec(ctx, fmt.Sprintf("kubectl get deployments --namespace %s -o json", shellEscape(ns)), gomock.Any()).Return([]byte(sampleJSON), nil, nil).Times(1)
 	deps, err := runner.KubectlGetDeployments(ctx, mockConn, ns, KubectlGetOptions{}); assert.NoError(t, err); assert.Equal(t, expected, deps)
 }


### PR DESCRIPTION
This commit attempts to address several issues and implement enhancements for the pkg/runner:

1.  **Syntax Error Corrections (Ongoing):**
    *   Corrected an import path in `pkg/runner/docker.go` from `pkg/utils` to `pkg/util`.
    *   Corrected a syntax error in `pkg/runner/kubectl_test.go` related to an improper variable declaration on a single line.
    *   Multiple attempts were made to fix a persistent syntax error in `pkg/runner/interface.go`. The error (`non-declaration statement outside function body`) indicates a misplaced closing brace for the `Runner` interface. This was primarily addressed by restoring the file and attempting targeted edits or full overwrites. The issue seems to stem from accurately modifying this large interface definition.
    *   A similar structural duplication issue in `pkg/runner/containerd.go` (related to `EnsureDefaultCrictlConfig`) was also addressed, primarily by restoring and then attempting a clean overwrite.

2.  **Feature Implementations in `pkg/runner/containerd.go`:**
    *   Implemented `EnsureDefaultContainerdConfig`: Writes a default `config.toml` if none exists or if the existing one is minimal. It includes logic to set `SystemdCgroup` based on facts and restarts the `containerd` service if changes are made.
    *   Enhanced `GetContainerdConfig` and `ConfigureContainerd`: These methods were improved for better (though still limited by the lack of a full TOML parsing library) TOML configuration management, focusing on specific common keys and appending registry mirror configurations.
    *   Implemented `EnsureDefaultCrictlConfig`: Writes a default `/etc/crictl.yaml` pointing to the containerd socket if the file doesn't exist or is empty. This method was also added to the `Runner` interface.
    *   Implemented/Updated most `crictl` methods based on `interface.go` definitions (PodSandbox lifecycle, container lifecycle within pods, inspection, logs, sync exec, version, info, stats). Placeholder implementations were replaced with actual `crictl` command execution and JSON parsing where appropriate.
    *   Implemented `CtrContainerInfo` for `ctr` based inspection of individual containers, including best-effort status detection.

3.  **Tests:**
    *   Added tests to `pkg/runner/containerd_test.go` for `EnsureDefaultContainerdConfig`, `EnsureDefaultCrictlConfig`, `CtrContainerInfo`, and key `crictl` methods (RunPodSandbox, StopPodSandbox, RemovePodSandbox, InspectPod, CreateContainerInPod).
    *   Reviewed `pkg/runner/docker_test.go` and found existing tests for Docker configuration and core methods to be largely sufficient for the current scope.

**Current Status & Known Issues:**
The primary blocking issue is a persistent syntax error in `pkg/runner/interface.go`. Despite multiple attempts to restore the file and carefully re-apply changes using both `replace_with_git_merge_diff` and `overwrite_file_with_block`, the Go compiler continues to report `syntax error: non-declaration statement outside function body`. This error suggests the `Runner` interface's closing brace is misplaced, causing method declarations that should be part of the interface to be seen as outside any valid block.

The latest attempts involved trying to overwrite `interface.go` with its full, hopefully correct, content. The error indicates this was not successful, and the interface definition is still malformed in the sandbox environment. The next step for this would have been another targeted attempt to fix the brace placement in `interface.go` or to request more specific guidance on manipulating this large file reliably.

Due to this persistent syntax error, I was unable to get `go test -v ./pkg/runner/...` to a state where it would compile and run all tests. The build failure messages (`FAIL github.com/mensylisir/kubexm/pkg/runner [build failed]`) are a direct result of this syntax error in `interface.go`.