### PR TITLE
Attempt to update runner interface and helpers

### DIFF
--- a/pkg/runner/docker.go
+++ b/pkg/runner/docker.go
@@ -79,14 +79,6 @@ func parseDockerSize(sizeStr string) (int64, error) {
 	return int64(value * float64(unit)), nil
 }
 
-// shellEscape ensures that a string is properly quoted for shell execution.
-func shellEscape(s string) string {
-	if s == "" {
-		return "''"
-	}
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
-
 // PullImage pulls a Docker image from a registry.
 func (r *defaultRunner) PullImage(ctx context.Context, c connector.Connector, imageName string) error {
 	if c == nil {
@@ -1762,16 +1754,6 @@ func (r *defaultRunner) DockerLoad(ctx context.Context, c connector.Connector, i
 		return errors.Wrapf(err, "failed to load image(s) from %s. Stderr: %s", inputFilePath, string(stderr))
 	}
 	return nil
-}
-
-// strPtr returns a pointer to the string value s.
-func strPtr(s string) *string {
-	return &s
-}
-
-// boolPtr returns a pointer to the bool value b.
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 // PruneDockerBuildCache prunes the Docker build cache.

--- a/pkg/runner/file.go
+++ b/pkg/runner/file.go
@@ -11,13 +11,6 @@ import (
 	"github.com/mensylisir/kubexm/pkg/connector" // Corrected import path
 )
 
-// shellEscape provides basic shell escaping for a string.
-// WARNING: This is a simplified version and may not cover all edge cases.
-// For production use, a more robust library or approach might be needed if paths can be arbitrary.
-func shellEscape(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
-
 // Exists checks if a file or directory exists at the given path.
 func (r *defaultRunner) Exists(ctx context.Context, conn connector.Connector, path string) (bool, error) {
 	if conn == nil {

--- a/pkg/runner/interface.go
+++ b/pkg/runner/interface.go
@@ -52,7 +52,6 @@ type ServiceInfo struct {
 	DaemonReloadCmd string
 }
 
-
 // Runner interface defines a complete, stateless host operation service library.
 type Runner interface {
 	GatherFacts(ctx context.Context, conn connector.Connector) (*Facts, error)
@@ -99,7 +98,6 @@ type Runner interface {
 	AddUser(ctx context.Context, conn connector.Connector, username, group, shell string, homeDir string, createHome bool, systemUser bool) error
 	AddGroup(ctx context.Context, conn connector.Connector, groupname string, systemGroup bool) error
 
-	// --- System & Kernel ---
 	LoadModule(ctx context.Context, conn connector.Connector, facts *Facts, moduleName string, params ...string) error
 	IsModuleLoaded(ctx context.Context, conn connector.Connector, moduleName string) (bool, error)
 	ConfigureModuleOnBoot(ctx context.Context, conn connector.Connector, facts *Facts, moduleName string, params ...string) error
@@ -107,8 +105,6 @@ type Runner interface {
 	SetTimezone(ctx context.Context, conn connector.Connector, facts *Facts, timezone string) error
 	DisableSwap(ctx context.Context, conn connector.Connector, facts *Facts) error
 	IsSwapEnabled(ctx context.Context, conn connector.Connector) (bool, error)
-
-	// --- Filesystem & Storage ---
 	EnsureMount(ctx context.Context, conn connector.Connector, device, mountPoint, fsType string, options []string, persistent bool) error
 	Unmount(ctx context.Context, conn connector.Connector, mountPoint string, force bool, sudo bool) error
 	IsMounted(ctx context.Context, conn connector.Connector, path string) (bool, error)
@@ -116,23 +112,15 @@ type Runner interface {
 	CreateSymlink(ctx context.Context, conn connector.Connector, target, linkPath string, sudo bool) error
 	GetDiskUsage(ctx context.Context, conn connector.Connector, path string) (total uint64, free uint64, used uint64, err error)
 	TouchFile(ctx context.Context, conn connector.Connector, path string, sudo bool) error
-
-	// --- Networking ---
 	DisableFirewall(ctx context.Context, conn connector.Connector, facts *Facts) error
 	GetInterfaceAddresses(ctx context.Context, conn connector.Connector, interfaceName string) (map[string][]string, error)
-
-	// --- User & Permissions ---
 	ModifyUser(ctx context.Context, conn connector.Connector, username string, modifications UserModifications) error
 	ConfigureSudoer(ctx context.Context, conn connector.Connector, sudoerName, content string) error
 	SetUserPassword(ctx context.Context, conn connector.Connector, username, hashedPassword string) error
 	GetUserInfo(ctx context.Context, conn connector.Connector, username string) (*UserInfo, error)
-
-	// --- High-Level ---
 	DeployAndEnableService(ctx context.Context, conn connector.Connector, facts *Facts, serviceName, configContent, configPath, permissions string, templateData interface{}) error
 	Reboot(ctx context.Context, conn connector.Connector, timeout time.Duration) error
-	RenderToString(ctx context.Context, tmpl *template.Template, data interface{}) (string, error) // Different from Render, no conn/destPath
-
-	// --- QEMU/libvirt Methods ---
+	RenderToString(ctx context.Context, tmpl *template.Template, data interface{}) (string, error)
 	CreateVMTemplate(ctx context.Context, conn connector.Connector, name string, osVariant string, memoryMB uint, vcpus uint, diskPath string, diskSizeGB uint, network string, graphicsType string, cloudInitISOPath string) error
 	ImportVMTemplate(ctx context.Context, conn connector.Connector, name string, filePath string) error
 	RefreshStoragePool(ctx context.Context, conn connector.Connector, poolName string) error
@@ -167,567 +155,443 @@ type Runner interface {
 	GetVMInfo(ctx context.Context, conn connector.Connector, vmName string) (*VMDetails, error)
 	GetVNCPort(ctx context.Context, conn connector.Connector, vmName string) (string, error)
 	EnsureLibvirtDaemonRunning(ctx context.Context, conn connector.Connector, facts *Facts) error
-
-
-	// --- Docker Methods ---
-
-	// PullImage pulls a Docker image from a registry.
-	// conn: Connector to the host where Docker daemon is running.
-	// imageName: Name of the image to pull (e.g., "ubuntu:latest").
 	PullImage(ctx context.Context, conn connector.Connector, imageName string) error
-
-	// ImageExists checks if a Docker image exists locally on the host.
-	// conn: Connector to the host.
-	// imageName: Name of the image to check.
 	ImageExists(ctx context.Context, conn connector.Connector, imageName string) (bool, error)
-
-	// ListImages lists Docker images available locally on the host.
-	// conn: Connector to the host.
-	// all: If true, includes intermediate image layers. If false, shows top-level images.
 	ListImages(ctx context.Context, conn connector.Connector, all bool) ([]ImageInfo, error)
-
-	// RemoveImage removes a Docker image from the host.
-	// conn: Connector to the host.
-	// imageName: Name of the image to remove.
-	// force: If true, forcefully remove the image (e.g., remove running containers using it).
 	RemoveImage(ctx context.Context, conn connector.Connector, imageName string, force bool) error
-
-	// BuildImage builds a Docker image from a Dockerfile.
-	// Note: Context handling for local paths requires the client to create a tar stream of the context.
-	// This implementation is simplified and might work best with URL contexts or require `r.Run("docker build ...")` for robustness with local file contexts.
-	// conn: Connector to the host.
-	// dockerfilePath: Path to the Dockerfile (can be relative to contextPath or a URL).
-	// imageNameAndTag: Name and tag for the built image (e.g., "myimage:latest").
-	// contextPath: Path to the build context (directory or URL to a git repo).
-	// buildArgs: Map of build-time variables.
 	BuildImage(ctx context.Context, conn connector.Connector, dockerfilePath string, imageNameAndTag string, contextPath string, buildArgs map[string]string) error
-
-	// CreateContainer creates a new Docker container from an image.
-	// conn: Connector to the host.
-	// options: ContainerCreateOptions struct detailing container configuration.
-	// Returns the ID of the created container.
 	CreateContainer(ctx context.Context, conn connector.Connector, options ContainerCreateOptions) (string, error)
-
-	// ContainerExists checks if a Docker container (by name or ID) exists on the host.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container.
 	ContainerExists(ctx context.Context, conn connector.Connector, containerNameOrID string) (bool, error)
-
-	// StartContainer starts an existing Docker container.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container to start.
 	StartContainer(ctx context.Context, conn connector.Connector, containerNameOrID string) error
-
-	// StopContainer stops a running Docker container.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container to stop.
-	// timeout: Optional duration to wait for graceful stop before killing the container. If nil, Docker default is used.
 	StopContainer(ctx context.Context, conn connector.Connector, containerNameOrID string, timeout *time.Duration) error
-
-	// RestartContainer restarts a Docker container.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container to restart.
-	// timeout: Optional duration to wait for stop before starting. If nil, Docker default is used.
 	RestartContainer(ctx context.Context, conn connector.Connector, containerNameOrID string, timeout *time.Duration) error
-
-	// RemoveContainer removes a Docker container from the host.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container to remove.
-	// force: If true, forcefully remove a running container.
-	// removeVolumes: If true, remove anonymous volumes associated with the container.
 	RemoveContainer(ctx context.Context, conn connector.Connector, containerNameOrID string, force bool, removeVolumes bool) error
-
-	// ListContainers lists Docker containers on the host.
-	// conn: Connector to the host.
-	// all: If true, lists all containers (including stopped). If false, only running.
-	// filters: Map of filters to apply (e.g., {"status": "running"}).
 	ListContainers(ctx context.Context, conn connector.Connector, all bool, filters map[string]string) ([]ContainerInfo, error)
-
-	// GetContainerLogs retrieves logs from a Docker container.
-	// Note: `options.Follow = true` is not suitable for this string-returning function signature;
-	// it would require a streaming approach (e.g., returning a channel).
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container.
-	// options: ContainerLogOptions specifying how to retrieve logs.
 	GetContainerLogs(ctx context.Context, conn connector.Connector, containerNameOrID string, options ContainerLogOptions) (string, error)
-
-	// GetContainerStats retrieves a stream of live resource usage statistics for a container.
-	// It returns a read-only channel from which `ContainerStats` can be received.
-	// The channel will be closed when the stream ends (e.g., context cancelled, container stops if not streaming indefinitely).
-	// The caller is responsible for consuming from the channel.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container.
-	// stream: If true, continuously stream stats. If false, get a single snapshot.
 	GetContainerStats(ctx context.Context, conn connector.Connector, containerNameOrID string, stream bool) (<-chan ContainerStats, error)
-
-	// InspectContainer retrieves detailed information about a Docker container.
-	// Returns nil if container not found (and no error).
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container.
 	InspectContainer(ctx context.Context, conn connector.Connector, containerNameOrID string) (*ContainerDetails, error)
-
-	// PauseContainer pauses all processes within a running Docker container.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container to pause.
 	PauseContainer(ctx context.Context, conn connector.Connector, containerNameOrID string) error
-
-	// UnpauseContainer unpauses all processes within a paused Docker container.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container to unpause.
 	UnpauseContainer(ctx context.Context, conn connector.Connector, containerNameOrID string) error
-
-	// ExecInContainer executes a command inside a running Docker container.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container.
-	// cmd: Command and arguments to execute.
-	// user: Optional user to run the command as.
-	// workDir: Optional working directory for the command.
-	// tty: If true, allocate a pseudo-TTY. Affects output stream format.
-	// Returns combined stdout/stderr output of the command.
 	ExecInContainer(ctx context.Context, conn connector.Connector, containerNameOrID string, cmd []string, user string, workDir string, tty bool) (string, error)
-
-	// CreateDockerNetwork creates a new Docker network.
-	// conn: Connector to the host.
-	// name: Name for the new network.
-	// driver: Network driver (e.g., "bridge", "overlay"). Defaults to "bridge" if empty by Docker.
-	// subnet: Optional subnet in CIDR format for IPAM configuration.
-	// gateway: Optional gateway for the subnet.
-	// options: Driver-specific options for the network.
 	CreateDockerNetwork(ctx context.Context, conn connector.Connector, name string, driver string, subnet string, gateway string, options map[string]string) error
-
-	// RemoveDockerNetwork removes a Docker network.
-	// conn: Connector to the host.
-	// networkNameOrID: Name or ID of the network to remove.
 	RemoveDockerNetwork(ctx context.Context, conn connector.Connector, networkNameOrID string) error
-
-	// ListDockerNetworks lists Docker networks on the host.
-	// conn: Connector to the host.
-	// filters: Map of filters to apply.
 	ListDockerNetworks(ctx context.Context, conn connector.Connector, filters map[string]string) ([]DockerNetworkInfo, error)
-
-	// ConnectContainerToNetwork connects a container to an existing Docker network.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container.
-	// networkNameOrID: Name or ID of the network.
-	// ipAddress: Optional static IPv4 address for the container on this network.
 	ConnectContainerToNetwork(ctx context.Context, conn connector.Connector, containerNameOrID string, networkNameOrID string, ipAddress string) error
-
-	// DisconnectContainerFromNetwork disconnects a container from a Docker network.
-	// conn: Connector to the host.
-	// containerNameOrID: Name or ID of the container.
-	// networkNameOrID: Name or ID of the network.
-	// force: If true, forcefully disconnect.
 	DisconnectContainerFromNetwork(ctx context.Context, conn connector.Connector, containerNameOrID string, networkNameOrID string, force bool) error
-
-	// CreateDockerVolume creates a new Docker volume.
-	// conn: Connector to the host.
-	// name: Name for the new volume.
-	// driver: Volume driver (e.g., "local"). Defaults to "local" if empty by Docker.
-	// driverOpts: Driver-specific options.
-	// labels: Labels to apply to the volume.
 	CreateDockerVolume(ctx context.Context, conn connector.Connector, name string, driver string, driverOpts map[string]string, labels map[string]string) error
-
-	// RemoveDockerVolume removes a Docker volume.
-	// conn: Connector to the host.
-	// volumeName: Name of the volume to remove.
-	// force: If true, forcefully remove the volume (e.g., if in use by a stopped container).
 	RemoveDockerVolume(ctx context.Context, conn connector.Connector, volumeName string, force bool) error
-
-	// ListDockerVolumes lists Docker volumes on the host.
-	// conn: Connector to the host.
-	// filters: Map of filters to apply.
 	ListDockerVolumes(ctx context.Context, conn connector.Connector, filters map[string]string) ([]DockerVolumeInfo, error)
-
-	// InspectDockerVolume retrieves detailed information about a Docker volume.
-	// Returns nil if volume not found (and no error).
-	// conn: Connector to the host.
-	// volumeName: Name of the volume.
 	InspectDockerVolume(ctx context.Context, conn connector.Connector, volumeName string) (*DockerVolumeDetails, error)
-
-	// DockerInfo retrieves system-wide information about the Docker daemon.
-	// conn: Connector to the host.
 	DockerInfo(ctx context.Context, conn connector.Connector) (*DockerSystemInfo, error)
-
-	// DockerPrune reclaims disk space by removing unused Docker resources.
-	// conn: Connector to the host.
-	// pruneType: Type of resource to prune ("containers", "images", "networks", "volumes", "system").
-	// filters: Filters to apply to the prune operation (semantics vary by pruneType).
-	// all: For images, `all=true` prunes all unused images, not just dangling ones. For system, influences image pruning.
-	// Returns a summary string of actions taken and space reclaimed.
 	DockerPrune(ctx context.Context, conn connector.Connector, pruneType string, filters map[string]string, all bool) (string, error)
 	GetDockerDaemonConfig(ctx context.Context, conn connector.Connector) (*DockerDaemonOptions, error)
 	ConfigureDockerDaemon(ctx context.Context, conn connector.Connector, opts DockerDaemonOptions, restartService bool) error
 	EnsureDefaultDockerConfig(ctx context.Context, conn connector.Connector, facts *Facts) error
-
-
-	// --- Containerd/ctr Methods ---
 	CtrListNamespaces(ctx context.Context, conn connector.Connector) ([]string, error)
 	CtrListImages(ctx context.Context, conn connector.Connector, namespace string) ([]CtrImageInfo, error)
 	CtrPullImage(ctx context.Context, conn connector.Connector, namespace, imageName string, allPlatforms bool, user string) error
 	CtrRemoveImage(ctx context.Context, conn connector.Connector, namespace, imageName string) error
 	CtrTagImage(ctx context.Context, conn connector.Connector, namespace, sourceImage, targetImage string) error
 	CtrListContainers(ctx context.Context, conn connector.Connector, namespace string) ([]CtrContainerInfo, error)
-	CtrRunContainer(ctx context.Context, conn connector.Connector, namespace string, opts ContainerdContainerCreateOptions) (string, error) // Returns container ID
+	CtrRunContainer(ctx context.Context, conn connector.Connector, namespace string, opts ContainerdContainerCreateOptions) (string, error)
 	CtrStopContainer(ctx context.Context, conn connector.Connector, namespace, containerID string, timeout time.Duration) error
 	CtrRemoveContainer(ctx context.Context, conn connector.Connector, namespace, containerID string) error
 	CtrExecInContainer(ctx context.Context, conn connector.Connector, namespace, containerID string, opts CtrExecOptions, cmd []string) (string, error)
 	CtrImportImage(ctx context.Context, conn connector.Connector, namespace, filePath string, allPlatforms bool) error
 	CtrExportImage(ctx context.Context, conn connector.Connector, namespace, imageName, outputFilePath string, allPlatforms bool) error
-	CtrContainerInfo(ctx context.Context, conn connector.Connector, namespace, containerID string) (*CtrContainerInfo, error) // For single container inspection
-
-	// --- Containerd/crictl Methods ---
+	CtrContainerInfo(ctx context.Context, conn connector.Connector, namespace, containerID string) (*CtrContainerInfo, error)
 	CrictlListImages(ctx context.Context, conn connector.Connector, filters map[string]string) ([]CrictlImageInfo, error)
 	CrictlPullImage(ctx context.Context, conn connector.Connector, imageName string, authCreds string, sandboxConfigPath string) error
 	CrictlRemoveImage(ctx context.Context, conn connector.Connector, imageName string) error
 	CrictlInspectImage(ctx context.Context, conn connector.Connector, imageName string) (*CrictlImageDetails, error)
 	CrictlImageFSInfo(ctx context.Context, conn connector.Connector) ([]CrictlFSInfo, error)
 	CrictlListPods(ctx context.Context, conn connector.Connector, filters map[string]string) ([]CrictlPodInfo, error)
-	CrictlRunPodSandbox(ctx context.Context, conn connector.Connector, podSandboxConfigFile string, runtimeHandler string) (string, error) // Returns Pod ID, replaces CrictlRunPod
-	CrictlStopPodSandbox(ctx context.Context, conn connector.Connector, podID string) error // Replaces CrictlStopPod
-	CrictlRemovePodSandbox(ctx context.Context, conn connector.Connector, podID string) error // Replaces CrictlRemovePod
+	CrictlRunPodSandbox(ctx context.Context, conn connector.Connector, podSandboxConfigFile string, runtimeHandler string) (string, error)
+	CrictlStopPodSandbox(ctx context.Context, conn connector.Connector, podID string) error
+	CrictlRemovePodSandbox(ctx context.Context, conn connector.Connector, podID string) error
 	CrictlInspectPod(ctx context.Context, conn connector.Connector, podID string) (*CrictlPodDetails, error)
-	CrictlPodSandboxStatus(ctx context.Context, conn connector.Connector, podID string, verbose bool) (*CrictlPodDetails, error) // verbose for more details
-	CrictlCreateContainerInPod(ctx context.Context, conn connector.Connector, podID string, containerConfigFile string, podSandboxConfigFile string) (string, error) // Replaces CrictlCreateContainer
-	CrictlStartContainerInPod(ctx context.Context, conn connector.Connector, containerID string) error // Replaces CrictlStartContainer
-	CrictlStopContainerInPod(ctx context.Context, conn connector.Connector, containerID string, timeout int64) error // Replaces CrictlStopContainer
-	CrictlRemoveContainerInPod(ctx context.Context, conn connector.Connector, containerID string, force bool) error // Replaces CrictlRemoveContainerForce, add force flag
-	CrictlInspectContainerInPod(ctx context.Context, conn connector.Connector, containerID string) (*CrictlContainerDetails, error) // Replaces CrictlInspectContainer
-	CrictlContainerStatus(ctx context.Context, conn connector.Connector, containerID string, verbose bool) (*CrictlContainerDetails, error) // verbose for more details
-	CrictlLogsForContainer(ctx context.Context, conn connector.Connector, containerID string, opts CrictlLogOptions) (string, error) // Replaces CrictlLogs
-	CrictlExecInContainerSync(ctx context.Context, conn connector.Connector, containerID string, timeout time.Duration, cmd []string) (stdout, stderr string, err error) // Replaces CrictlExec, sync version
-	CrictlExecInContainerAsync(ctx context.Context, conn connector.Connector, containerID string, cmd []string) (string, error) // For async exec, returns request ID or similar
+	CrictlPodSandboxStatus(ctx context.Context, conn connector.Connector, podID string, verbose bool) (*CrictlPodDetails, error)
+	CrictlCreateContainerInPod(ctx context.Context, conn connector.Connector, podID string, containerConfigFile string, podSandboxConfigFile string) (string, error)
+	CrictlStartContainerInPod(ctx context.Context, conn connector.Connector, containerID string) error
+	CrictlStopContainerInPod(ctx context.Context, conn connector.Connector, containerID string, timeout int64) error
+	CrictlRemoveContainerInPod(ctx context.Context, conn connector.Connector, containerID string, force bool) error
+	CrictlInspectContainerInPod(ctx context.Context, conn connector.Connector, containerID string) (*CrictlContainerDetails, error)
+	CrictlContainerStatus(ctx context.Context, conn connector.Connector, containerID string, verbose bool) (*CrictlContainerDetails, error)
+	CrictlLogsForContainer(ctx context.Context, conn connector.Connector, containerID string, opts CrictlLogOptions) (string, error)
+	CrictlExecInContainerSync(ctx context.Context, conn connector.Connector, containerID string, timeout time.Duration, cmd []string) (stdout, stderr string, err error)
+	CrictlExecInContainerAsync(ctx context.Context, conn connector.Connector, containerID string, cmd []string) (string, error)
 	CrictlPortForward(ctx context.Context, conn connector.Connector, podID string, ports []string) (string, error)
 	CrictlVersion(ctx context.Context, conn connector.Connector) (*CrictlVersionInfo, error)
-	CrictlInfo(ctx context.Context, conn connector.Connector) (*CrictlRuntimeInfo, error) // For `crictl info`
+	CrictlInfo(ctx context.Context, conn connector.Connector) (*CrictlRuntimeInfo, error)
 	CrictlRuntimeConfig(ctx context.Context, conn connector.Connector) (string, error)
-	CrictlStats(ctx context.Context, conn connector.Connector, resourceID string, outputFormat string) (string, error) // resourceID can be pod or container ID
+	CrictlStats(ctx context.Context, conn connector.Connector, resourceID string, outputFormat string) (string, error)
 	CrictlPodStats(ctx context.Context, conn connector.Connector, outputFormat string, podID string) (string, error)
 	ConfigureCrictl(ctx context.Context, conn connector.Connector, configFileContent string, configFilePath string) error
 	EnsureDefaultContainerdConfig(ctx context.Context, conn connector.Connector, facts *Facts) error
 	GetContainerdConfig(ctx context.Context, conn connector.Connector) (*ContainerdConfigOptions, error)
 	ConfigureContainerd(ctx context.Context, conn connector.Connector, opts ContainerdConfigOptions, restartService bool) error
-
-
-	// --- Helm Methods ---
 	HelmInstall(ctx context.Context, conn connector.Connector, releaseName, chartPath string, opts HelmInstallOptions) error
 	HelmUninstall(ctx context.Context, conn connector.Connector, releaseName string, opts HelmUninstallOptions) error
 	HelmList(ctx context.Context, conn connector.Connector, opts HelmListOptions) ([]HelmReleaseInfo, error)
-	HelmStatus(ctx context.Context, conn connector.Connector, releaseName string, opts HelmStatusOptions) (*HelmReleaseInfo, error) // Single release status
+	HelmStatus(ctx context.Context, conn connector.Connector, releaseName string, opts HelmStatusOptions) (*HelmReleaseInfo, error)
 	HelmRepoAdd(ctx context.Context, conn connector.Connector, name, url string, opts HelmRepoAddOptions) error
 	HelmRepoUpdate(ctx context.Context, conn connector.Connector, repoNames []string) error
 	HelmSearchRepo(ctx context.Context, conn connector.Connector, keyword string, opts HelmSearchOptions) ([]HelmChartInfo, error)
-	HelmPull(ctx context.Context, conn connector.Connector, chartPath string, opts HelmPullOptions) (string, error) // Returns path to downloaded chart
+	HelmPull(ctx context.Context, conn connector.Connector, chartPath string, opts HelmPullOptions) (string, error)
 	HelmPackage(ctx context.Context, conn connector.Connector, chartPath string, opts HelmPackageOptions) (string, error)
 	HelmVersion(ctx context.Context, conn connector.Connector) (*HelmVersionInfo, error)
 	HelmUpgrade(ctx context.Context, conn connector.Connector, releaseName, chartPath string, opts HelmUpgradeOptions) error
 	HelmRollback(ctx context.Context, conn connector.Connector, releaseName string, revision int, opts HelmRollbackOptions) error
 	HelmHistory(ctx context.Context, conn connector.Connector, releaseName string, opts HelmHistoryOptions) ([]HelmReleaseRevisionInfo, error)
-	HelmGetValues(ctx context.Context, conn connector.Connector, releaseName string, opts HelmGetOptions) (string, error)    // Returns raw values (YAML string)
-	HelmGetManifest(ctx context.Context, conn connector.Connector, releaseName string, opts HelmGetOptions) (string, error) // Returns raw manifest (YAML string)
-	HelmGetHooks(ctx context.Context, conn connector.Connector, releaseName string, opts HelmGetOptions) (string, error)    // Returns raw hooks (YAML string)
-	HelmTemplate(ctx context.Context, conn connector.Connector, releaseName, chartPath string, opts HelmTemplateOptions) (string, error) // Returns rendered YAML string
+	HelmGetValues(ctx context.Context, conn connector.Connector, releaseName string, opts HelmGetOptions) (string, error)
+	HelmGetManifest(ctx context.Context, conn connector.Connector, releaseName string, opts HelmGetOptions) (string, error)
+	HelmGetHooks(ctx context.Context, conn connector.Connector, releaseName string, opts HelmGetOptions) (string, error)
+	HelmTemplate(ctx context.Context, conn connector.Connector, releaseName, chartPath string, opts HelmTemplateOptions) (string, error)
 	HelmDependencyUpdate(ctx context.Context, conn connector.Connector, chartPath string, opts HelmDependencyOptions) error
-	HelmLint(ctx context.Context, conn connector.Connector, chartPath string, opts HelmLintOptions) (string, error) // Returns linting output
+	HelmLint(ctx context.Context, conn connector.Connector, chartPath string, opts HelmLintOptions) (string, error)
+	KubectlApply(ctx context.Context, conn connector.Connector, opts KubectlApplyOptions) (string, error)
+	KubectlGet(ctx context.Context, conn connector.Connector, resourceType string, resourceName string, opts KubectlGetOptions) (string, error)
+	KubectlDescribe(ctx context.Context, conn connector.Connector, resourceType string, resourceName string, opts KubectlDescribeOptions) (string, error)
+	KubectlDelete(ctx context.Context, conn connector.Connector, resourceType string, resourceName string, opts KubectlDeleteOptions) error
+	KubectlLogs(ctx context.Context, conn connector.Connector, podName string, opts KubectlLogOptions) (string, error)
+	KubectlExec(ctx context.Context, conn connector.Connector, podName string, opts KubectlExecOptions, command ...string) (string, error)
+	KubectlVersion(ctx context.Context, conn connector.Connector) (*KubectlVersionInfo, error)
+	KubectlClusterInfo(ctx context.Context, conn connector.Connector, kubeconfigPath string) (string, error)
+	KubectlGetNodes(ctx context.Context, conn connector.Connector, opts KubectlGetOptions) ([]KubectlNodeInfo, error)
+	KubectlGetPods(ctx context.Context, conn connector.Connector, opts KubectlGetOptions) ([]KubectlPodInfo, error)
+	KubectlGetServices(ctx context.Context, conn connector.Connector, opts KubectlGetOptions) ([]KubectlServiceInfo, error)
+	KubectlGetDeployments(ctx context.Context, conn connector.Connector, opts KubectlGetOptions) ([]KubectlDeploymentInfo, error)
+	KubectlGetResourceList(ctx context.Context, conn connector.Connector, resourceType string, opts KubectlGetOptions) ([]map[string]interface{}, error)
+	KubectlRolloutStatus(ctx context.Context, conn connector.Connector, resourceType, resourceName string, opts KubectlRolloutOptions) (string, error)
+	KubectlRolloutHistory(ctx context.Context, conn connector.Connector, resourceType, resourceName string, opts KubectlRolloutOptions) (string, error)
+	KubectlRolloutUndo(ctx context.Context, conn connector.Connector, resourceType, resourceName string, toRevision int, opts KubectlRolloutOptions) error
+	KubectlScale(ctx context.Context, conn connector.Connector, resourceType, resourceName string, replicas int32, opts KubectlScaleOptions) error
+	KubectlConfigView(ctx context.Context, conn connector.Connector, opts KubectlConfigViewOptions) (*KubectlConfigInfo, error)
+	KubectlConfigGetContexts(ctx context.Context, conn connector.Connector, kubeconfigPath string) ([]KubectlContextInfo, error)
+	KubectlConfigUseContext(ctx context.Context, conn connector.Connector, contextName string, kubeconfigPath string) error
+	KubectlConfigCurrentContext(ctx context.Context, conn connector.Connector, kubeconfigPath string) (string, error)
+	KubectlTopNodes(ctx context.Context, conn connector.Connector, opts KubectlTopOptions) ([]KubectlMetricsInfo, error)
+	KubectlTopPods(ctx context.Context, conn connector.Connector, opts KubectlTopOptions) ([]KubectlMetricsInfo, error)
+	KubectlPortForward(ctx context.Context, conn connector.Connector, resourceType, resourceName string, ports []string, opts KubectlPortForwardOptions) error
+	KubectlExplain(ctx context.Context, conn connector.Connector, resourceType string, opts KubectlExplainOptions) (string, error)
+	KubectlDrainNode(ctx context.Context, conn connector.Connector, nodeName string, opts KubectlDrainOptions) error
+	KubectlCordonNode(ctx context.Context, conn connector.Connector, nodeName string, opts KubectlCordonUncordonOptions) error
+	KubectlUncordonNode(ctx context.Context, conn connector.Connector, nodeName string, opts KubectlCordonUncordonOptions) error
+	KubectlTaintNode(ctx context.Context, conn connector.Connector, nodeName string, taints []string, opts KubectlTaintOptions) error
+	KubectlCreateSecretGeneric(ctx context.Context, conn connector.Connector, namespace, name string, fromLiterals map[string]string, fromFiles map[string]string, opts KubectlCreateOptions) error
+	KubectlCreateSecretDockerRegistry(ctx context.Context, conn connector.Connector, namespace, name, dockerServer, dockerUsername, dockerPassword, dockerEmail string, opts KubectlCreateOptions) error
+	KubectlCreateSecretTLS(ctx context.Context, conn connector.Connector, namespace, name, certPath, keyPath string, opts KubectlCreateOptions) error
+	KubectlCreateConfigMap(ctx context.Context, conn connector.Connector, namespace, name string, fromLiterals map[string]string, fromFiles map[string]string, fromEnvFile string, opts KubectlCreateOptions) error
+	KubectlCreateServiceAccount(ctx context.Context, conn connector.Connector, namespace, name string, opts KubectlCreateOptions) error
+	KubectlCreateRole(ctx context.Context, conn connector.Connector, namespace, name string, verbs, resources, resourceNames []string, opts KubectlCreateOptions) error
+	KubectlCreateClusterRole(ctx context.Context, conn connector.Connector, name string, verbs, resources, resourceNames []string, aggregationRule string, opts KubectlCreateOptions) error
+	KubectlCreateRoleBinding(ctx context.Context, conn connector.Connector, namespace, name, role, serviceAccount string, users, groups []string, opts KubectlCreateOptions) error
+	KubectlCreateClusterRoleBinding(ctx context.Context, conn connector.Connector, name, clusterRole, serviceAccount string, users, groups []string, opts KubectlCreateOptions) error
+	KubectlSetImage(ctx context.Context, conn connector.Connector, resourceType, resourceName, containerName, newImage string, opts KubectlSetOptions) error
+	KubectlSetEnv(ctx context.Context, conn connector.Connector, resourceType, resourceName, containerName string, envVars map[string]string, removeEnvVars []string, fromSecret, fromConfigMap string, opts KubectlSetOptions) error
+	KubectlSetResources(ctx context.Context, conn connector.Connector, resourceType, resourceName, containerName string, limits, requests map[string]string, opts KubectlSetOptions) error
+	KubectlAutoscale(ctx context.Context, conn connector.Connector, resourceType, resourceName string, minReplicas, maxReplicas int32, cpuPercent int32, opts KubectlAutoscaleOptions) error
+	KubectlCompletion(ctx context.Context, conn connector.Connector, shell string) (string, error)
+	KubectlWait(ctx context.Context, conn connector.Connector, resourceType, resourceName string, condition string, opts KubectlWaitOptions) error
+	KubectlLabel(ctx context.Context, conn connector.Connector, resourceType, resourceName string, labels map[string]string, overwrite bool, opts KubectlLabelOptions) error
+	KubectlAnnotate(ctx context.Context, conn connector.Connector, resourceType, resourceName string, annotations map[string]string, overwrite bool, opts KubectlAnnotateOptions) error
+	KubectlPatch(ctx context.Context, conn connector.Connector, resourceType, resourceName string, patchType, patchContent string, opts KubectlPatchOptions) error
 }
 
-// --- Helm Supporting Structs ---
-
 type HelmInstallOptions struct {
-	Namespace       string   // Namespace to install the release into
-	KubeconfigPath  string   // Path to kubeconfig file on the target host
-	ValuesFiles     []string // List of paths to values files
-	SetValues       []string // List of set values (e.g., "key1=value1,key2.subkey=value2")
-	Version         string   // Specify chart version
-	CreateNamespace bool     // Whether to create the namespace if it doesn't exist
-	Wait            bool     // If true, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state
-	Timeout         time.Duration // Time to wait for any individual Kubernetes operation (like Jobs for hooks)
-	Atomic          bool     // If true, installation process purges chart on fail. The --wait flag will be set automatically if --atomic is used
-	DryRun          bool     // Simulate an install
-	Devel           bool     // Use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
-	Description     string   // Add a custom description
-	Sudo            bool     // If helm command itself needs sudo
-	Retries         int      // Number of retries for the command execution
-	RetryDelay      time.Duration // Delay between retries
+	Namespace       string
+	KubeconfigPath  string
+	ValuesFiles     []string
+	SetValues       []string
+	Version         string
+	CreateNamespace bool
+	Wait            bool
+	Timeout         time.Duration
+	Atomic          bool
+	DryRun          bool
+	Devel           bool
+	Description     string
+	Sudo            bool
+	Retries         int
+	RetryDelay      time.Duration
 }
 
 type HelmUninstallOptions struct {
-	Namespace      string        // Namespace of the release
-	KubeconfigPath string        // Path to kubeconfig file
-	KeepHistory    bool          // If true, remove all associated resources and mark the release as deleted, but retain the release history
-	Timeout        time.Duration // Time to wait for any individual Kubernetes operation (like Jobs for hooks)
-	DryRun         bool          // Simulate an uninstall
+	Namespace      string
+	KubeconfigPath string
+	KeepHistory    bool
+	Timeout        time.Duration
+	DryRun         bool
 	Sudo           bool
 }
 
 type HelmListOptions struct {
-	Namespace      string            // Scope this list to a specific namespace
-	KubeconfigPath string            // Path to kubeconfig file
-	AllNamespaces  bool              // List releases across all namespaces
-	Filter         string            // A regular expression (Perl compatible) to filter the list (e.g., `helm list --filter 'myrelease.+`)
-	Selector       string            // Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-	Max            int               // Maximum number of releases to fetch (0 for no limit)
-	Offset         int               // Next release index in the list, used to offset from start value
-	ByDate         bool              // Sort by release date
-	SortReverse    bool              // Sort in reverse order (implies --by-date)
-	Deployed       bool              // Show deployed releases. If no other is specified, this will be automatically enabled
-	Failed         bool              // Show failed releases
-	Pending        bool              // Show pending releases
-	Uninstalled    bool              // Show uninstalled releases (if 'helm list --uninstalled')
-	Uninstalling   bool              // Show releases that are currently uninstalling
+	Namespace      string
+	KubeconfigPath string
+	AllNamespaces  bool
+	Filter         string
+	Selector       string
+	Max            int
+	Offset         int
+	ByDate         bool
+	SortReverse    bool
+	Deployed       bool
+	Failed         bool
+	Pending        bool
+	Uninstalled    bool
+	Uninstalling   bool
 	Sudo           bool
 }
 
-type HelmReleaseInfo struct { // Based on `helm list -o json` and `helm status -o json`
+type HelmReleaseInfo struct {
 	Name         string `json:"name"`
 	Namespace    string `json:"namespace"`
-	Revision     string `json:"revision"` // string because it can be large
-	Updated      string `json:"updated"`  // Timestamp string e.g. "2023-10-27 10:30:00.123 -0700 MST"
-	Status       string `json:"status"`   // e.g. "deployed", "failed", "pending-install"
-	Chart        string `json:"chart"`    // Chart name with version e.g. "nginx-1.12.3"
-	AppVersion   string `json:"app_version"` // Application version from the chart
-	Notes        string `json:"notes,omitempty"` // Only from `helm status`
-	Config       map[string]interface{} `json:"config,omitempty"` // User-supplied values, only from `helm status`
-	Manifest     string `json:"manifest,omitempty"` // Rendered manifest, only from `helm status` (can be huge)
-	Version      int    `json:"version"` // Alias for revision, sometimes present
+	Revision     string `json:"revision"`
+	Updated      string `json:"updated"`
+	Status       string `json:"status"`
+	Chart        string `json:"chart"`
+	AppVersion   string `json:"app_version"`
+	Notes        string `json:"notes,omitempty"`
+	Config       map[string]interface{} `json:"config,omitempty"`
+	Manifest     string `json:"manifest,omitempty"`
+	Version      int    `json:"version"`
 }
 
 
 type HelmStatusOptions struct {
-	Namespace      string // Namespace of the release
-	KubeconfigPath string // Path to kubeconfig file
-	Revision       int    // If set, display the status of the named release at a specific revision
-	ShowDesc       bool   // If true, display the description given to the release
+	Namespace      string
+	KubeconfigPath string
+	Revision       int
+	ShowDesc       bool
 	Sudo           bool
 }
 
 type HelmRepoAddOptions struct {
-	Username       string // Chart repository username
-	Password       string // Chart repository password
-	CAFile         string // Verify certificates of HTTPS-enabled servers using this CA bundle
-	CertFile       string // Identify HTTPS client using this SSL certificate file
-	KeyFile        string // Identify HTTPS client using this SSL key file
-	Insecure       bool   // Skip TLS certificate checks for the repository
-	ForceUpdate    bool   // Replace the repository if it already exists
-	PassCredentials bool  // Pass credentials to all domains
+	Username       string
+	Password       string
+	CAFile         string
+	CertFile       string
+	KeyFile        string
+	Insecure       bool
+	ForceUpdate    bool
+	PassCredentials bool
 	Sudo           bool
 }
 
-type HelmSearchOptions struct { // For `helm search repo`
-	Regexp      bool   // Use regular expressions for searching
-	Devel       bool   // Use development versions, too (equivalent to version '>0.0.0-0')
-	Version     string // Specify a version constraint for the chart version (e.g. "~1.0.0")
-	Versions    bool   // Show all versions of charts (equivalent to --version '>')
-	OutputFormat string // Output format: table, json, yaml. Default is table.
+type HelmSearchOptions struct {
+	Regexp      bool
+	Devel       bool
+	Version     string
+	Versions    bool
+	OutputFormat string
 	Sudo        bool
 }
 
-type HelmChartInfo struct { // Based on `helm search repo -o json`
-	Name        string `json:"name"`        // e.g. "stable/nginx-ingress"
-	Version     string `json:"version"`     // e.g. "1.41.3"
-	AppVersion  string `json:"app_version"` // e.g. "0.30.0"
-	Description string `json:"description"`
-}
-
-type HelmPullOptions struct {
-	Destination    string // Location to write the chart. If this and tardir are specified, tardir is appended to destination
-	Prov           bool   // Fetch the provenance file, but don't perform verification
-	Untar          bool   // If set to true, pull the chart then untar it in tardir
-	UntarDir       string // If untar is specified, this flag specifies the directory to untar the chart after downloading it (default ".")
-	Verify         bool   // Verify the package against its signature
-	Keyring        string // Keyring containing public keys (default "$HOME/.gnupg/pubring.gpg")
-	Version        string // Specify a version constraint for the chart version. If this is not specified, the latest version is downloaded
-	CAFile         string // Verify certificates of HTTPS-enabled servers using this CA bundle
-	CertFile       string // Identify HTTPS client using this SSL certificate file
-	KeyFile        string // Identify HTTPS client using this SSL key file
-	Insecure       bool   // Skip TLS certificate checks for the repository
-	Devel          bool   // Use development versions too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
-	PassCredentials bool  // Pass credentials to all domains
-	Username       string // Chart repository username
-	Password       string // Chart repository password
-	Sudo           bool
-}
-
-type HelmPackageOptions struct {
-	Destination  string   // Location to write the chart archive (default ".")
-	Sign         bool     // Use a GPG key to sign this package
-	Key          string   // Name of the GPG key to use when signing
-	Keyring      string   // Keyring containing private keys (default "$HOME/.gnupg/secring.gpg")
-	PassphraseFile string // Location of a file containing the GPG passphrase
-	Version      string   // Set the package version. Overrides the version in Chart.yaml
-	AppVersion   string   // Set the appVersion. Overrides the appVersion in Chart.yaml
-	DependencyUpdate bool // Update chart dependencies before packaging
-	Sudo         bool
-}
-
-type HelmUpgradeOptions struct {
-	HelmInstallOptions // Embeds most common options from install
-	Install          bool // If a release by this name doesn't already exist, run an install
-	Force            bool // Force resource updates through a replacement strategy
-	ResetValues      bool // When upgrading, reset the values to the ones built into the chart
-	ReuseValues      bool // When upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f
-	CleanupOnFail    bool // Allow deletion of new resources created in this upgrade when upgrade fails
-	MaxHistory       int  // Limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)
-}
-
-type HelmRollbackOptions struct {
-	Namespace      string        // Namespace of the release
-	KubeconfigPath string        // Path to kubeconfig file
-	Timeout        time.Duration // Time to wait for any individual Kubernetes operation
-	Wait           bool          // If set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state
-	CleanupOnFail  bool          // Allow deletion of new resources created in this rollback when rollback fails
-	DryRun         bool          // Simulate a rollback
-	Force          bool          // Force resource updates through a replacement strategy
-	NoHooks        bool          // Prevent hooks from running during rollback
-	RecreatePods   bool          // Performs pods restart for the resource if applicable
-	Sudo           bool
-}
-
-type HelmHistoryOptions struct {
-	Namespace      string // Namespace of the release
-	KubeconfigPath string // Path to kubeconfig file
-	OutputFormat   string // Output format: table, json, yaml. Default is table.
-	Max            int    // Maximum number of revisions to include in history (0 for no limit)
-	Sudo           bool
-}
-
-type HelmReleaseRevisionInfo struct { // Based on `helm history <release> -o json`
-	Revision    int    `json:"revision"`
-	Updated     string `json:"updated"` // Timestamp string
-	Status      string `json:"status"`  // e.g. "superseded", "deployed"
-	Chart       string `json:"chart"`   // e.g. "nginx-1.12.3"
+type HelmChartInfo struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
 	AppVersion  string `json:"app_version"`
 	Description string `json:"description"`
 }
 
-type HelmGetOptions struct { // For `helm get values/manifest/hooks`
-	Namespace      string // Namespace of the release
-	KubeconfigPath string // Path to kubeconfig file
-	Revision       int    // Get the named release at a specific revision
-	AllValues      bool   // When used with `get values`, dump all computed values (implies --output json or yaml)
+type HelmPullOptions struct {
+	Destination    string
+	Prov           bool
+	Untar          bool
+	UntarDir       string
+	Verify         bool
+	Keyring        string
+	Version        string
+	CAFile         string
+	CertFile       string
+	KeyFile        string
+	Insecure       bool
+	Devel          bool
+	PassCredentials bool
+	Username       string
+	Password       string
+	Sudo           bool
+}
+
+type HelmPackageOptions struct {
+	Destination  string
+	Sign         bool
+	Key          string
+	Keyring      string
+	PassphraseFile string
+	Version      string
+	AppVersion   string
+	DependencyUpdate bool
+	Sudo         bool
+}
+
+type HelmUpgradeOptions struct {
+	HelmInstallOptions
+	Install          bool
+	Force            bool
+	ResetValues      bool
+	ReuseValues      bool
+	CleanupOnFail    bool
+	MaxHistory       int
+}
+
+type HelmRollbackOptions struct {
+	Namespace      string
+	KubeconfigPath string
+	Timeout        time.Duration
+	Wait           bool
+	CleanupOnFail  bool
+	DryRun         bool
+	Force          bool
+	NoHooks        bool
+	RecreatePods   bool
+	Sudo           bool
+}
+
+type HelmHistoryOptions struct {
+	Namespace      string
+	KubeconfigPath string
+	OutputFormat   string
+	Max            int
+	Sudo           bool
+}
+
+type HelmReleaseRevisionInfo struct {
+	Revision    int    `json:"revision"`
+	Updated     string `json:"updated"`
+	Status      string `json:"status"`
+	Chart       string `json:"chart"`
+	AppVersion  string `json:"app_version"`
+	Description string `json:"description"`
+}
+
+type HelmGetOptions struct {
+	Namespace      string
+	KubeconfigPath string
+	Revision       int
+	AllValues      bool
 	Sudo           bool
 }
 
 type HelmTemplateOptions struct {
-	Namespace       string   // Namespace to install the release into
-	KubeconfigPath  string   // Path to kubeconfig file
-	ValuesFiles     []string // List of paths to values files
-	SetValues       []string // List of set values
-	ReleaseName     string   // Use this name for the release (defaults to "RELEASE-NAME")
-	CreateNamespace bool     // Whether to create the namespace if it doesn't exist
-	ShowOnly        []string // Only show manifests rendered from the given templates
-	SkipCrds        bool     // If true, no CRDs will be installed. By default, CRDs are installed if not already present
-	Validate        bool     // Validate your manifests against the Kubernetes cluster you are currently targeting
-	IncludeCrds     bool     // Include CRDs in the templated output
-	IsUpgrade       bool     // Set .Release.IsUpgrade instead of .Release.IsInstall
+	Namespace       string
+	KubeconfigPath  string
+	ValuesFiles     []string
+	SetValues       []string
+	ReleaseName     string
+	CreateNamespace bool
+	ShowOnly        []string
+	SkipCrds        bool
+	Validate        bool
+	IncludeCrds     bool
+	IsUpgrade       bool
 	Sudo            bool
 }
 
-type HelmDependencyOptions struct { // For `helm dependency update/build/list`
-	Keyring        string // Keyring containing public keys (default "$HOME/.gnupg/pubring.gpg")
-	SkipRefresh    bool   // Do not refresh the local repository cache
-	Verify         bool   // Verify the packages against signatures
+type HelmDependencyOptions struct {
+	Keyring        string
+	SkipRefresh    bool
+	Verify         bool
 	Sudo           bool
 }
 
 type HelmLintOptions struct {
-	Strict         bool     // Fail on lint warnings
-	ValuesFiles    []string // List of paths to values files
-	SetValues      []string // List of set values
-	Quiet          bool     // Print only warnings and errors
-	WithSubcharts  bool     // Lint subcharts also
-	Namespace      string   // Namespace to install the release into (used for validation)
-	KubeVersion    string   // Kubernetes version to validate against (e.g., "v1.25.0")
+	Strict         bool
+	ValuesFiles    []string
+	SetValues      []string
+	Quiet          bool
+	WithSubcharts  bool
+	Namespace      string
+	KubeVersion    string
 	Sudo           bool
 }
 
 
-type HelmVersionInfo struct { // Based on `helm version -o json`
-	Version      string `json:"version"`    // e.g. "v3.7.0"
+type HelmVersionInfo struct {
+	Version      string `json:"version"`
 	GitCommit  string `json:"gitCommit"`
 	GitTreeState string `json:"gitTreeState"`
 	GoVersion  string `json:"goVersion"`
 }
 
-// --- Kubectl Supporting Structs ---
-
 type KubectlApplyOptions struct {
-	KubeconfigPath string   // Path to kubeconfig file
-	Namespace      string   // Namespace for the apply operation
-	Force          bool     // Force apply updates
-	Prune          bool     // Prune unmanaged resources
-	Selector       string   // Selector (label query) to filter on for pruning
-	DryRun         string   // "none", "client", or "server". Default "none".
-	Validate       bool     // Validate schemas. Default true. (For older kubectl, might be string "true"/"false")
-	Filenames      []string // List of filenames, URLs, or '-' for stdin. If using stdin, FileContent must be provided.
-	FileContent    string   // Content to apply if Filenames contains '-'.
-	Recursive      bool     // If true, process directory recursively.
+	KubeconfigPath string
+	Namespace      string
+	Force          bool
+	Prune          bool
+	Selector       string
+	DryRun         string
+	Validate       bool
+	Filenames      []string
+	FileContent    string
+	Recursive      bool
 	Sudo           bool
 }
 
 type KubectlGetOptions struct {
-	KubeconfigPath string   // Path to kubeconfig file
-	Namespace      string   // Namespace for the get operation
-	AllNamespaces  bool     // If true, get from all namespaces
-	OutputFormat   string   // Output format: json, yaml, wide, name, custom-columns=..., go-template=...
-	Selector       string   // Selector (label query) to filter on
-	FieldSelector  string   // Selector (field query) to filter on
-	Watch          bool     // Watch for changes
-	IgnoreNotFound bool     // If true, ignore "not found" errors
-	ChunkSize      int64    // Return large lists in chunks rather than all at once. (0 for no chunking)
-	LabelColumns   []string // Additional columns to display for wide output
-	ShowLabels     bool     // When printing, show all labels as columns
+	KubeconfigPath string
+	Namespace      string
+	AllNamespaces  bool
+	OutputFormat   string
+	Selector       string
+	FieldSelector  string
+	Watch          bool
+	IgnoreNotFound bool
+	ChunkSize      int64
+	LabelColumns   []string
+	ShowLabels     bool
 	Sudo           bool
 }
 
 type KubectlDescribeOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	Namespace      string // Namespace for the describe operation
-	Selector       string // Selector (label query) to filter on
-	ShowEvents     bool   // Include events in describe output (default true)
+	KubeconfigPath string
+	Namespace      string
+	Selector       string
+	ShowEvents     bool
 	Sudo           bool
 }
 
 type KubectlDeleteOptions struct {
-	KubeconfigPath string   // Path to kubeconfig file
-	Namespace      string   // Namespace for the delete operation
-	Force          bool     // Force deletion ofgrace period 0
-	GracePeriod    *int64   // Period of time in seconds given to the resource to terminate gracefully. Ignored if negative.
-	Timeout        time.Duration // The length of time to wait before giving up on a delete, zero means determine a timeout from the grace period
-	Wait           bool     // If true, wait for resources to be gone before returning. This may be slow.
-	Selector       string   // Selector (label query) to filter on
-	Filenames      []string // List of filenames, URLs, or '-' for stdin.
-	FileContent    string   // Content to delete if Filenames contains '-'.
-	Recursive      bool     // If true, process directory recursively.
-	IgnoreNotFound bool     // If true, ignore "not found" errors
-	Cascade        string   // "true", "false", or "orphan". If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicaSet).
+	KubeconfigPath string
+	Namespace      string
+	Force          bool
+	GracePeriod    *int64
+	Timeout        time.Duration
+	Wait           bool
+	Selector       string
+	Filenames      []string
+	FileContent    string
+	Recursive      bool
+	IgnoreNotFound bool
+	Cascade        string
 	Sudo           bool
 }
 
 type KubectlLogOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	Namespace      string // Namespace of the pod
-	Container      string // Container name within the pod
-	Follow         bool   // Follow the log stream
-	Previous       bool   // Print the logs for the previous instance of the container in a pod if it exists
-	SinceTime      string // Only return logs newer than a specific date (RFC3339)
-	SinceSeconds   *int64 // Only return logs newer than a relative duration like 5s, 2m, or 1h.
-	TailLines      *int64 // If set, the number of lines from the end of the logs to show.
-	LimitBytes     *int64 // If set, the maximum number of bytes to read from the log.
-	Timestamps     bool   // Include timestamps on each line in the log output
+	KubeconfigPath string
+	Namespace      string
+	Container      string
+	Follow         bool
+	Previous       bool
+	SinceTime      string
+	SinceSeconds   *int64
+	TailLines      *int64
+	LimitBytes     *int64
+	Timestamps     bool
 	Sudo           bool
 }
 
 type KubectlExecOptions struct {
-	KubeconfigPath string        // Path to kubeconfig file
-	Namespace      string        // Namespace of the pod
-	Container      string        // Container name within the pod
-	Stdin          bool          // Pass stdin to the container
-	TTY            bool          // Allocate a pseudo-TTY
-	CommandTimeout time.Duration // Timeout for the exec command itself (not for the process in container unless it's interactive and this runner handles it)
+	KubeconfigPath string
+	Namespace      string
+	Container      string
+	Stdin          bool
+	TTY            bool
+	CommandTimeout time.Duration
 	Sudo           bool
 }
 
-type KubectlVersionInfo struct { // Based on `kubectl version -o json`
+type KubectlVersionInfo struct {
 	ClientVersion struct {
 		Major        string `json:"major"`
 		Minor        string `json:"minor"`
@@ -739,7 +603,7 @@ type KubectlVersionInfo struct { // Based on `kubectl version -o json`
 		Compiler     string `json:"compiler"`
 		Platform     string `json:"platform"`
 	} `json:"clientVersion"`
-	ServerVersion *struct { // ServerVersion can be null if server is unreachable
+	ServerVersion *struct {
 		Major        string `json:"major"`
 		Minor        string `json:"minor"`
 		GitVersion   string `json:"gitVersion"`
@@ -752,7 +616,6 @@ type KubectlVersionInfo struct { // Based on `kubectl version -o json`
 	} `json:"serverVersion,omitempty"`
 }
 
-// KubectlNodeInfo is a simplified struct for `kubectl get nodes -o json` items
 type KubectlNodeInfo struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
@@ -767,21 +630,20 @@ type KubectlNodeInfo struct {
 		PodCIDR           string `json:"podCIDR"`
 		ProviderID        string `json:"providerID"`
 		Unschedulable     bool   `json:"unschedulable,omitempty"`
-		// Taints might be here
 	} `json:"spec"`
 	Status struct {
 		Capacity    map[string]string `json:"capacity"`
 		Allocatable map[string]string `json:"allocatable"`
 		Conditions  []struct {
-			Type               string `json:"type"` // e.g., Ready, MemoryPressure
-			Status             string `json:"status"` // True, False, Unknown
+			Type               string `json:"type"`
+			Status             string `json:"status"`
 			LastHeartbeatTime  string `json:"lastHeartbeatTime"`
 			LastTransitionTime string `json:"lastTransitionTime"`
 			Reason             string `json:"reason"`
 			Message            string `json:"message"`
 		} `json:"conditions"`
 		Addresses []struct {
-			Type    string `json:"type"` // e.g., InternalIP, Hostname
+			Type    string `json:"type"`
 			Address string `json:"address"`
 		} `json:"addresses"`
 		NodeInfo struct {
@@ -794,11 +656,9 @@ type KubectlNodeInfo struct {
 			KubeletVersion          string `json:"kubeletVersion"`
 			KubeProxyVersion        string `json:"kubeProxyVersion"`
 		} `json:"nodeInfo"`
-		// Images, DaemonEndpoints might be here
 	} `json:"status"`
 }
 
-// KubectlPodInfo is a simplified struct for `kubectl get pods -o json` items
 type KubectlPodInfo struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
@@ -821,36 +681,30 @@ type KubectlPodInfo struct {
 		Containers []struct {
 			Name  string `json:"name"`
 			Image string `json:"image"`
-			// Ports, Env, Resources, VolumeMounts etc.
 		} `json:"containers"`
-		// Volumes, RestartPolicy, TerminationGracePeriodSeconds etc.
 	} `json:"spec"`
 	Status struct {
-		Phase             string `json:"phase"` // Pending, Running, Succeeded, Failed, Unknown
+		Phase             string `json:"phase"`
 		HostIP            string `json:"hostIP"`
 		PodIP             string `json:"podIP"`
 		StartTime         string `json:"startTime,omitempty"`
 		ContainerStatuses []struct {
 			Name        string `json:"name"`
-			State       map[string]interface{} `json:"state"` // e.g. {"running":{"startedAt":"..."}} or {"terminated":{"exitCode":0,...}}
+			State       map[string]interface{} `json:"state"`
 			LastState   map[string]interface{} `json:"lastState,omitempty"`
 			Ready       bool   `json:"ready"`
 			RestartCount int32  `json:"restartCount"`
 			Image       string `json:"image"`
 			ImageID     string `json:"imageID"`
-			ContainerID string `json:"containerID"` // e.g. containerd://<hash>
+			ContainerID string `json:"containerID"`
 		} `json:"containerStatuses,omitempty"`
 		Conditions []struct {
 			Type   string `json:"type"`
 			Status string `json:"status"`
-			// LastProbeTime, LastTransitionTime
 		} `json:"conditions,omitempty"`
-		// QOSClass
 	} `json:"status"`
 }
 
-
-// KubectlServiceInfo for `kubectl get svc -o json`
 type KubectlServiceInfo struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
@@ -867,17 +721,16 @@ type KubectlServiceInfo struct {
 			Name       string `json:"name,omitempty"`
 			Protocol   string `json:"protocol"`
 			Port       int32  `json:"port"`
-			TargetPort any    `json:"targetPort"` // Can be int or string
+			TargetPort any    `json:"targetPort"`
 			NodePort   int32  `json:"nodePort,omitempty"`
 		} `json:"ports"`
 		Selector      map[string]string `json:"selector,omitempty"`
 		ClusterIP     string            `json:"clusterIP"`
 		ClusterIPs    []string          `json:"clusterIPs,omitempty"`
-		Type          string            `json:"type"` // e.g., ClusterIP, NodePort, LoadBalancer
+		Type          string            `json:"type"`
 		SessionAffinity string          `json:"sessionAffinity"`
 		ExternalIPs   []string          `json:"externalIPs,omitempty"`
 		LoadBalancerIP string           `json:"loadBalancerIP,omitempty"`
-		// ... other fields like healthCheckNodePort, externalTrafficPolicy etc.
 	} `json:"spec"`
 	Status struct {
 		LoadBalancer struct {
@@ -889,7 +742,6 @@ type KubectlServiceInfo struct {
 	} `json:"status,omitempty"`
 }
 
-// KubectlDeploymentInfo for `kubectl get deploy -o json`
 type KubectlDeploymentInfo struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
@@ -908,13 +760,12 @@ type KubectlDeploymentInfo struct {
 			MatchLabels map[string]string `json:"matchLabels"`
 		} `json:"selector"`
 		Template struct {
-			// PodTemplateSpec metadata and spec
 		} `json:"template"`
 		Strategy struct {
 			Type    string `json:"type"`
 			RollingUpdate *struct {
-				MaxUnavailable any `json:"maxUnavailable,omitempty"` // int or string
-				MaxSurge       any `json:"maxSurge,omitempty"`       // int or string
+				MaxUnavailable any `json:"maxUnavailable,omitempty"`
+				MaxSurge       any `json:"maxSurge,omitempty"`
 			} `json:"rollingUpdate,omitempty"`
 		} `json:"strategy"`
 		MinReadySeconds      int32 `json:"minReadySeconds,omitempty"`
@@ -930,60 +781,19 @@ type KubectlDeploymentInfo struct {
 		AvailableReplicas   int32 `json:"availableReplicas,omitempty"`
 		UnavailableReplicas int32 `json:"unavailableReplicas,omitempty"`
 		Conditions []struct {
-			Type   string `json:"type"` // e.g. Available, Progressing
+			Type   string `json:"type"`
 			Status string `json:"status"`
-			// LastUpdateTime, LastTransitionTime, Reason, Message
 		} `json:"conditions,omitempty"`
 	} `json:"status,omitempty"`
 }
 
-
-type KubectlRolloutOptions struct {
-	KubeconfigPath string        // Path to kubeconfig file
-	Namespace      string        // Namespace for the resource
-	Watch          bool          // Watch the status of the rollout until it's done
-	Timeout        time.Duration // Timeout for watching the rollout status
-	Sudo           bool
-}
-
-type KubectlScaleOptions struct {
-	KubeconfigPath    string        // Path to kubeconfig file
-	Namespace         string        // Namespace for the resource
-	CurrentReplicas   *int32        // Precondition for current replicas
-	ResourceVersion   *string       // Precondition for resource version
-	Timeout           time.Duration // Timeout for the operation to complete
-	Sudo              bool
-}
-
-type KubectlPortForwardOptions struct {
-	KubeconfigPath string   // Path to kubeconfig file
-	Namespace      string   // Namespace for the pod/service
-	Address        []string // Addresses to listen on (default: localhost). Use "0.0.0.0" for all interfaces.
-	PodRunningTimeout time.Duration // The length of time to wait for a pod to be running
-	Sudo           bool
-	// Note: PortForward is typically a long-running process. This runner function might start it in background
-	// or require a way to manage its lifecycle (e.g., return a process handle or use context for cancellation).
-	// For simplicity, it might just establish the forward and return, or block.
-}
-
-type KubectlConfigViewOptions struct {
-	KubeconfigPath string // Path to kubeconfig file(s)
-	Minify         bool   // Remove all information not used by current-context
-	Raw            bool   // Display raw byte data
-	OutputFormat   string // json or yaml
-	Sudo           bool
-}
-
-// KubectlConfigInfo represents parsed output of `kubectl config view -o json`
-// This is a complex structure, so a simplified version or map[string]interface{} might be used initially.
 type KubectlConfigInfo struct {
 	APIVersion     string `json:"apiVersion"`
 	Clusters       []struct {
 		Name    string `json:"name"`
 		Cluster struct {
 			Server                   string `json:"server"`
-			CertificateAuthorityData string `json:"certificate-authority-data,omitempty"` // Base64 encoded
-			// InsecureSkipTLSVerify  bool   `json:"insecure-skip-tls-verify,omitempty"`
+			CertificateAuthorityData string `json:"certificate-authority-data,omitempty"`
 		} `json:"cluster"`
 	} `json:"clusters"`
 	Contexts []struct {
@@ -1000,44 +810,40 @@ type KubectlConfigInfo struct {
 	Users []struct {
 		Name string `json:"name"`
 		User struct {
-			ClientCertificateData string `json:"client-certificate-data,omitempty"` // Base64
-			ClientKeyData         string `json:"client-key-data,omitempty"`         // Base64
+			ClientCertificateData string `json:"client-certificate-data,omitempty"`
+			ClientKeyData         string `json:"client-key-data,omitempty"`
 			Token                 string `json:"token,omitempty"`
-			// Username, Password, AuthProvider, Exec etc.
 		} `json:"user"`
 	} `json:"users"`
 }
 
-
-type KubectlContextInfo struct { // From `kubectl config get-contexts -o json`
+type KubectlContextInfo struct {
 	Name    string `json:"name"`
 	Cluster string `json:"cluster"`
-	AuthInfo string `json:"user"` // "user" in JSON output refers to AuthInfo
+	AuthInfo string `json:"user"`
 	Namespace string `json:"namespace,omitempty"`
-	Current bool   // Indicated by '*' in text output, needs special handling if parsing text or specific JSON field if available
+	Current bool
 }
 
-
-// KubectlMetricsInfo for `kubectl top node/pod -o json` (common fields)
 type KubectlMetricsInfo struct {
 	Metadata struct {
 		Name              string    `json:"name"`
-		CreationTimestamp time.Time `json:"timestamp"` // Kubectl top uses "timestamp"
+		CreationTimestamp time.Time `json:"timestamp"`
 	} `json:"metadata"`
-	Timestamp string `json:"timestamp"` // Top-level timestamp for the metrics
-	Window    string `json:"window"`    // e.g., "1m0s"
-	Containers []KubectlContainerMetricsInfo `json:"containers,omitempty"` // For top pod
+	Timestamp string `json:"timestamp"`
+	Window    string `json:"window"`
+	Containers []KubectlContainerMetricsInfo `json:"containers,omitempty"`
 	CPU struct {
-		UsageNanoCores string `json:"usageNanoCores,omitempty"` // String like "12345n"
-		UsageCoreNanos *int64 `json:"-"` // Parsed value
-	} `json:"cpu,omitempty"` // For top node, CPU is directly under root
+		UsageNanoCores string `json:"usageNanoCores,omitempty"`
+		UsageCoreNanos *int64 `json:"-"`
+	} `json:"cpu,omitempty"`
 	Memory struct {
-		UsageBytes string `json:"usageBytes,omitempty"` // String like "12345Ki" or "6789Mi"
-		UsageBytesParsed *int64 `json:"-"` // Parsed value in bytes
-	} `json:"memory,omitempty"` // For top node, Memory is directly under root
+		UsageBytes string `json:"usageBytes,omitempty"`
+		UsageBytesParsed *int64 `json:"-"`
+	} `json:"memory,omitempty"`
 }
 
-type KubectlContainerMetricsInfo struct { // For `kubectl top pod <pod> --containers -o json`
+type KubectlContainerMetricsInfo struct {
 	Name string `json:"name"`
 	CPU struct {
 		UsageNanoCores string `json:"usageNanoCores,omitempty"`
@@ -1049,58 +855,16 @@ type KubectlContainerMetricsInfo struct { // For `kubectl top pod <pod> --contai
 	} `json:"memory"`
 }
 
-
-// KubectlRolloutOptions, KubectlScaleOptions, KubectlPortForwardOptions
-// would also need to be defined based on their respective kubectl command flags and JSON outputs.
-// For brevity, these are listed as comments but would be fully fleshed out.
-	KubectlTopNodes(ctx context.Context, conn connector.Connector, opts KubectlTopOptions) ([]KubectlMetricsInfo, error)
-	KubectlTopPods(ctx context.Context, conn connector.Connector, opts KubectlTopOptions) ([]KubectlMetricsInfo, error)
-	KubectlPortForward(ctx context.Context, conn connector.Connector, resourceType, resourceName string, ports []string, opts KubectlPortForwardOptions) error // Typically long-running, might need backgrounding/cancellation
-	KubectlExplain(ctx context.Context, conn connector.Connector, resourceType string, opts KubectlExplainOptions) (string, error)
-	KubectlDrainNode(ctx context.Context, conn connector.Connector, nodeName string, opts KubectlDrainOptions) error
-	KubectlCordonNode(ctx context.Context, conn connector.Connector, nodeName string, opts KubectlCordonUncordonOptions) error
-	KubectlUncordonNode(ctx context.Context, conn connector.Connector, nodeName string, opts KubectlCordonUncordonOptions) error
-	KubectlTaintNode(ctx context.Context, conn connector.Connector, nodeName string, taints []string, opts KubectlTaintOptions) error
-	KubectlCreateSecretGeneric(ctx context.Context, conn connector.Connector, namespace, name string, fromLiterals map[string]string, fromFiles map[string]string, opts KubectlCreateOptions) error
-	KubectlCreateSecretDockerRegistry(ctx context.Context, conn connector.Connector, namespace, name, dockerServer, dockerUsername, dockerPassword, dockerEmail string, opts KubectlCreateOptions) error
-	KubectlCreateSecretTLS(ctx context.Context, conn connector.Connector, namespace, name, certPath, keyPath string, opts KubectlCreateOptions) error
-	KubectlCreateConfigMap(ctx context.Context, conn connector.Connector, namespace, name string, fromLiterals map[string]string, fromFiles map[string]string, fromEnvFile string, opts KubectlCreateOptions) error
-	KubectlCreateServiceAccount(ctx context.Context, conn connector.Connector, namespace, name string, opts KubectlCreateOptions) error
-	KubectlCreateRole(ctx context.Context, conn connector.Connector, namespace, name string, verbs, resources, resourceNames []string, opts KubectlCreateOptions) error
-	KubectlCreateClusterRole(ctx context.Context, conn connector.Connector, name string, verbs, resources, resourceNames []string, aggregationRule string, opts KubectlCreateOptions) error
-	KubectlCreateRoleBinding(ctx context.Context, conn connector.Connector, namespace, name, role, serviceAccount string, users, groups []string, opts KubectlCreateOptions) error
-	KubectlCreateClusterRoleBinding(ctx context.Context, conn connector.Connector, name, clusterRole, serviceAccount string, users, groups []string, opts KubectlCreateOptions) error
-	KubectlSetImage(ctx context.Context, conn connector.Connector, resourceType, resourceName, containerName, newImage string, opts KubectlSetOptions) error
-	KubectlSetEnv(ctx context.Context, conn connector.Connector, resourceType, resourceName, containerName string, envVars map[string]string, removeEnvVars []string, fromSecret, fromConfigMap string, opts KubectlSetOptions) error
-	KubectlSetResources(ctx context.Context, conn connector.Connector, resourceType, resourceName, containerName string, limits, requests map[string]string, opts KubectlSetOptions) error
-	KubectlAutoscale(ctx context.Context, conn connector.Connector, resourceType, resourceName string, minReplicas, maxReplicas int32, cpuPercent int32, opts KubectlAutoscaleOptions) error
-	KubectlCompletion(ctx context.Context, conn connector.Connector, shell string) (string, error) // shell: bash, zsh, fish, powershell
-	KubectlWait(ctx context.Context, conn connector.Connector, resourceType, resourceName string, condition string, opts KubectlWaitOptions) error
-	KubectlLabel(ctx context.Context, conn connector.Connector, resourceType, resourceName string, labels map[string]string, overwrite bool, opts KubectlLabelOptions) error
-	KubectlAnnotate(ctx context.Context, conn connector.Connector, resourceType, resourceName string, annotations map[string]string, overwrite bool, opts KubectlAnnotateOptions) error
-	KubectlPatch(ctx context.Context, conn connector.Connector, resourceType, resourceName string, patchType, patchContent string, opts KubectlPatchOptions) error
-
-// --- Containerd/ctr Supporting Structs ---
-
-// ContainerdConfigOptions represents a subset of configurable options for Containerd's config.toml.
-// This is highly simplified. Real config.toml is complex and uses TOML.
-// Representing it fully in Go structs for JSON-like merging is non-trivial.
-// Often, users might provide a full template or specific sections to merge.
-// For this example, we'll keep it very basic.
-// A more robust approach for TOML would involve a TOML parser/merger.
 type ContainerdConfigOptions struct {
-	Version      *int    `toml:"version,omitempty" json:"version,omitempty"` // config.toml version
-	Root         *string `toml:"root,omitempty" json:"root,omitempty"`       // containerd root directory
-	State        *string `toml:"state,omitempty" json:"state,omitempty"`      // containerd state directory
+	Version      *int    `toml:"version,omitempty" json:"version,omitempty"`
+	Root         *string `toml:"root,omitempty" json:"root,omitempty"`
+	State        *string `toml:"state,omitempty" json:"state,omitempty"`
+	OOMScore     *int    `toml:"oom_score,omitempty" json:"oom_score,omitempty"`
 	GRPC         *ContainerdGRPCConfig `toml:"grpc,omitempty" json:"grpc,omitempty"`
 	Metrics      *ContainerdMetricsConfig `toml:"metrics,omitempty" json:"metrics,omitempty"`
 	DisabledPlugins *[]string `toml:"disabled_plugins,omitempty" json:"disabled_plugins,omitempty"`
-	// Plugins map allows for arbitrary plugin configuration.
-	// map[string]map[string]interface{} would be `[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]`
-	// This is very hard to model generically with strong types for all possible plugins.
-	// For specific common needs like registry mirrors, dedicated fields are better.
-	PluginConfigs *map[string]interface{} `toml:"plugins,omitempty" json:"plugins,omitempty"` // For arbitrary plugin sections
-	RegistryMirrors map[string][]string `toml:"-" json:"-"` // Special handling: map of registry to list of mirror endpoints
+	PluginConfigs *map[string]interface{} `toml:"plugins,omitempty" json:"plugins,omitempty"`
+	RegistryMirrors map[string][]string `toml:"-" json:"-"`
 }
 
 type ContainerdGRPCConfig struct {
@@ -1116,63 +880,58 @@ type ContainerdMetricsConfig struct {
 	GRPCHistogram *bool   `toml:"grpc_histogram,omitempty" json:"grpc_histogram,omitempty"`
 }
 
-
 type CtrImageInfo struct {
-	Name   string   // Image name (e.g., docker.io/library/alpine:latest)
-	Digest string   // Image digest (e.g., sha256:...)
-	Size   string   // Human-readable size (e.g., "2.83 MiB")
-	OSArch string   // OS/Architecture (e.g., linux/amd64)
+	Name   string
+	Digest string
+	Size   string
+	OSArch string
 	Labels map[string]string
 }
 
 type CtrContainerInfo struct {
 	ID      string
 	Image   string
-	Runtime string // e.g., io.containerd.runc.v2
-	Status  string // e.g., RUNNING, STOPPED, CREATED - Needs parsing from `ctr c list`
+	Runtime string
+	Status  string
 	Labels  map[string]string
 }
 
-// ContainerdContainerCreateOptions mirrors relevant fields from `ctr run` or `ctr c create`
 type ContainerdContainerCreateOptions struct {
-	ImageName     string   // Image to use
-	ContainerID   string   // ID for the new container
-	Snapshotter   string   // Snapshotter to use (e.g., "overlayfs")
-	ConfigPath    string   // Path to OCI spec file (optional, ctr can generate)
-	Runtime       string   // Runtime to use (e.g., "io.containerd.runc.v2")
-	NetHost       bool     // Use host network
-	TTY           bool     // Allocate TTY
-	Env           []string // Environment variables "KEY=value"
-	Mounts        []string // Mounts in "type=TYPE,src=SRC,dst=DST,options=OPT" format
-	Command       []string // Command to run
+	ImageName     string
+	ContainerID   string
+	Snapshotter   string
+	ConfigPath    string
+	Runtime       string
+	NetHost       bool
+	TTY           bool
+	Env           []string
+	Mounts        []string
+	Command       []string
 	Labels        map[string]string
-	RemoveExisting bool    // Remove container with same ID if it exists
+	RemoveExisting bool
 	Privileged    bool
 	ReadOnlyRootFS bool
-	User          string // user[:group]
-	Cwd           string // Working directory
-	Platforms     []string // For multi-platform images, e.g. "linux/amd64"
+	User          string
+	Cwd           string
+	Platforms     []string
 }
 
 type CtrExecOptions struct {
 	TTY  bool
-	User string // user[:group]
+	User string
 	Cwd  string
 }
-
-
-// --- Containerd/crictl Supporting Structs ---
 
 type CrictlImageInfo struct {
 	ID          string   `json:"id"`
 	RepoTags    []string `json:"repoTags"`
 	RepoDigests []string `json:"repoDigests"`
-	Size        string   `json:"size"` // crictl outputs size as string e.g. "5.57MB"
-	UID         *int64   `json:"uid"`  // User ID to run the image as
+	Size        string   `json:"size"`
+	UID         *int64   `json:"uid"`
 	Username    string   `json:"username"`
 }
 
-type CrictlImageDetails struct { // Based on `crictl inspecti`
+type CrictlImageDetails struct {
 	Status struct {
 		ID          string   `json:"id"`
 		RepoTags    []string `json:"repoTags"`
@@ -1181,7 +940,7 @@ type CrictlImageDetails struct { // Based on `crictl inspecti`
 		Username    string   `json:"username"`
 		UID         *int64   `json:"uid"`
 	} `json:"status"`
-	Info map[string]interface{} `json:"info"` // Raw JSON info from image config
+	Info map[string]interface{} `json:"info"`
 }
 
 type CrictlFSInfo struct {
@@ -1189,7 +948,7 @@ type CrictlFSInfo struct {
 	FsID struct {
 		Mountpoint string `json:"mountpoint"`
 	} `json:"fsId"`
-	UsedBytes  string `json:"usedBytes"` // e.g., "1.23GB"
+	UsedBytes  string `json:"usedBytes"`
 	InodesUsed string `json:"inodesUsed"`
 }
 
@@ -1198,14 +957,14 @@ type CrictlPodInfo struct {
 	Name           string            `json:"name"`
 	Namespace      string            `json:"namespace"`
 	Attempt        uint32            `json:"attempt"`
-	State          string            `json:"state"` // e.g., "SANDBOX_READY", "SANDBOX_NOTREADY"
-	CreatedAt      string            `json:"createdAt"` // Timestamp string
+	State          string            `json:"state"`
+	CreatedAt      string            `json:"createdAt"`
 	Labels         map[string]string `json:"labels"`
 	Annotations    map[string]string `json:"annotations"`
 	RuntimeHandler string            `json:"runtimeHandler"`
 }
 
-type CrictlPodDetails struct { // Based on `crictl inspectp`
+type CrictlPodDetails struct {
 	Status struct {
 		ID             string            `json:"id"`
 		Metadata struct {
@@ -1218,14 +977,13 @@ type CrictlPodDetails struct { // Based on `crictl inspectp`
 		CreatedAt      string            `json:"createdAt"`
 		Network struct {
 			IP       string `json:"ip"`
-			// AdditionalIPs might be present
 		} `json:"network"`
 		Linux struct {
 			Namespaces struct {
 				Options struct {
-					Network string `json:"network"` // "POD", "NODE"
-					Pid     string `json:"pid"`     // "POD", "NODE", "TARGET" (for container)
-					Ipc     string `json:"ipc"`     // "POD", "NODE"
+					Network string `json:"network"`
+					Pid     string `json:"pid"`
+					Ipc     string `json:"ipc"`
 				} `json:"options"`
 			} `json:"namespaces"`
 		} `json:"linux"`
@@ -1233,27 +991,27 @@ type CrictlPodDetails struct { // Based on `crictl inspectp`
 		Annotations    map[string]string `json:"annotations"`
 		RuntimeHandler string            `json:"runtimeHandler"`
 	} `json:"status"`
-	Info map[string]interface{} `json:"info"` // Raw JSON from runtime
+	Info map[string]interface{} `json:"info"`
 }
 
 
-type CrictlContainerDetails struct { // Based on `crictl inspect` (for containers)
+type CrictlContainerDetails struct {
 	Status struct {
 		ID       string `json:"id"`
 		Metadata struct {
 			Name    string `json:"name"`
 			Attempt uint32 `json:"attempt"`
 		} `json:"metadata"`
-		State       string            `json:"state"` // e.g., "CONTAINER_RUNNING", "CONTAINER_EXITED"
+		State       string            `json:"state"`
 		CreatedAt   string            `json:"createdAt"`
 		StartedAt   string            `json:"startedAt"`
 		FinishedAt  string            `json:"finishedAt"`
 		ExitCode    int32             `json:"exitCode"`
 		Image struct {
-			Image string `json:"image"` // Image name
-			ID    string `json:"id"`    // Image ID
+			Image string `json:"image"`
+			ID    string `json:"id"`
 		} `json:"image"`
-		ImageRef    string            `json:"imageRef"` // Image ID (same as Image.ID usually)
+		ImageRef    string            `json:"imageRef"`
 		Reason      string            `json:"reason"`
 		Message     string            `json:"message"`
 		Labels      map[string]string `json:"labels"`
@@ -1262,38 +1020,32 @@ type CrictlContainerDetails struct { // Based on `crictl inspect` (for container
 			ContainerPath  string `json:"containerPath"`
 			HostPath       string `json:"hostPath"`
 			Readonly       bool   `json:"readonly"`
-			Propagation    string `json:"propagation"` // e.g. "PROPAGATION_PRIVATE"
+			Propagation    string `json:"propagation"`
 			SelinuxRelabel bool   `json:"selinuxRelabel"`
 		} `json:"mounts"`
 		LogPath     string `json:"logPath"`
 	} `json:"status"`
 	Pid  int                    `json:"pid"`
-	Info map[string]interface{} `json:"info"` // Raw JSON from runtime
+	Info map[string]interface{} `json:"info"`
 }
 
 
-type CrictlLogOptions struct { // Based on `crictl logs` flags
-	Follow     bool   // -f, --follow
-	TailLines  *int64 // -t, --tail (use pointer to distinguish 0 from not set)
-	Since      string // --since (duration like 10s, 1m, or RFC3339Nano timestamp)
-	Timestamps bool   // --timestamps
-	Latest     bool   // --latest (deprecated, use tail)
-	NumLines   *int64 // -l, --lines (alternative to tail)
+type CrictlLogOptions struct {
+	Follow     bool
+	TailLines  *int64
+	Since      string
+	Timestamps bool
+	Latest     bool
+	NumLines   *int64
 }
 
-type CrictlVersionInfo struct { // Based on `crictl version`
+type CrictlVersionInfo struct {
 	Version           string
 	RuntimeName       string
 	RuntimeVersion    string
 	RuntimeApiVersion string
 }
 
-
-// --- Docker Supporting Structs ---
-
-// DockerDaemonOptions represents a subset of configurable options in daemon.json.
-// Fields are pointers to distinguish between a deliberately empty value (e.g., empty array)
-// and a value that should not be configured (nil pointer).
 type DockerDaemonOptions struct {
 	LogDriver         *string            `json:"log-driver,omitempty"`
 	LogOpts           *map[string]string `json:"log-opts,omitempty"`
@@ -1301,9 +1053,9 @@ type DockerDaemonOptions struct {
 	StorageOpts       *[]string          `json:"storage-opts,omitempty"`
 	RegistryMirrors   *[]string          `json:"registry-mirrors,omitempty"`
 	InsecureRegistries *[]string          `json:"insecure-registries,omitempty"`
-	ExecOpts          *[]string          `json:"exec-opts,omitempty"` // e.g., ["native.cgroupdriver=systemd"]
-	Bridge            *string            `json:"bridge,omitempty"`    // e.g., "docker0"
-	Bip               *string            `json:"bip,omitempty"`       // e.g., "192.168.1.5/24"
+	ExecOpts          *[]string          `json:"exec-opts,omitempty"`
+	Bridge            *string            `json:"bridge,omitempty"`
+	Bip               *string            `json:"bip,omitempty"`
 	FixedCIDR         *string            `json:"fixed-cidr,omitempty"`
 	DefaultGateway    *string            `json:"default-gateway,omitempty"`
 	DNS               *[]string          `json:"dns,omitempty"`
@@ -1311,443 +1063,393 @@ type DockerDaemonOptions struct {
 	Experimental      *bool              `json:"experimental,omitempty"`
 	Debug             *bool              `json:"debug,omitempty"`
 	APICorsHeader     *string            `json:"api-cors-header,omitempty"`
-	Hosts             *[]string          `json:"hosts,omitempty"` // e.g. ["tcp://0.0.0.0:2375", "unix:///var/run/docker.sock"]
+	Hosts             *[]string          `json:"hosts,omitempty"`
 	UserlandProxy     *bool              `json:"userland-proxy,omitempty"`
 	LiveRestore       *bool              `json:"live-restore,omitempty"`
 	CgroupParent      *string            `json:"cgroup-parent,omitempty"`
 	DefaultRuntime    *string            `json:"default-runtime,omitempty"`
 	Runtimes          *map[string]DockerRuntime `json:"runtimes,omitempty"`
-	Graph             *string            `json:"graph,omitempty"` // Deprecated: use data-root
-	DataRoot          *string            `json:"data-root,omitempty"` // e.g. /var/lib/docker
+	Graph             *string            `json:"graph,omitempty"`
+	DataRoot          *string            `json:"data-root,omitempty"`
 	MaxConcurrentDownloads *int          `json:"max-concurrent-downloads,omitempty"`
 	MaxConcurrentUploads   *int          `json:"max-concurrent-uploads,omitempty"`
 	ShutdownTimeout        *int          `json:"shutdown-timeout,omitempty"`
-	// Add more fields as needed from https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file
-	// Using pointers for all fields to allow distinguishing between unset and explicitly set to default (e.g. false for bool)
 }
 
-// DockerRuntime defines the structure for runtime configurations within DockerDaemonOptions.
 type DockerRuntime struct {
 	Path string `json:"path"`
 	RuntimeArgs []string `json:"runtimeArgs,omitempty"`
 }
 
-
-// ImageInfo holds basic information about a Docker image.
 type ImageInfo struct {
-	ID          string   // ID of the image.
-	RepoTags    []string // Repository tags associated with the image.
-	Created     string   // Timestamp string of image creation time.
-	Size        int64    // Size of the image in bytes.
-	VirtualSize int64    // Virtual size of the image in bytes (size on disk).
+	ID          string
+	RepoTags    []string
+	Created     string
+	Size        int64
+	VirtualSize int64
 }
 
-// ContainerPortMapping defines port mappings for a container.
 type ContainerPortMapping struct {
-	HostIP        string // Host IP address to bind to.
-	HostPort      string // Host port number.
-	ContainerPort string // Container port number.
-	Protocol      string // Protocol (e.g., "tcp", "udp").
+	HostIP        string
+	HostPort      string
+	ContainerPort string
+	Protocol      string
 }
 
-// ContainerMount defines a mount point for a container.
 type ContainerMount struct {
-	Type        string // Type of mount (e.g., "bind", "volume", "tmpfs").
-	Source      string // Path on the host (for bind mounts) or name of the volume.
-	Destination string // Path inside the container where the mount is visible.
-	Mode        string // Mount mode (e.g., "ro" for read-only, "rw" for read-write).
+	Type        string
+	Source      string
+	Destination string
+	Mode        string
 }
 
-// ContainerCreateOptions encapsulates parameters for creating a Docker container.
 type ContainerCreateOptions struct {
-	ImageName        string            // Name of the image to use for the container.
-	ContainerName    string            // Optional name for the container; Docker generates one if empty.
-	Ports            []ContainerPortMapping // Port mappings.
-	Volumes          []ContainerMount  // Volume mounts.
-	EnvVars          []string          // Environment variables in "VAR=value" format.
-	Command          []string          // Command to run in the container (overrides image's CMD).
-	Entrypoint       []string          // Entrypoint for the container (overrides image's ENTRYPOINT).
-	WorkingDir       string            // Working directory inside the container.
-	User             string            // Username or UID to run commands as inside the container.
-	RestartPolicy    string            // Restart policy (e.g., "no", "on-failure:3", "always", "unless-stopped").
-	NetworkMode      string            // Network mode (e.g., "bridge", "host", "none", "container:<name|id>", "<network_name>").
-	ExtraHosts       []string          // Hosts to add to the container's /etc/hosts file ("hostname:ip").
-	Labels           map[string]string // Labels to apply to the container.
-	Privileged       bool              // If true, run the container in privileged mode.
-	CapAdd           []string          // Linux capabilities to add to the container.
-	CapDrop          []string          // Linux capabilities to drop from the container.
-	Resources        ContainerResources // CPU, Memory limits/reservations.
-	HealthCheck      *ContainerHealthCheck // Health check configuration for the container.
-	AutoRemove       bool              // If true, automatically remove the container when it exits (--rm flag).
-	VolumesFrom      []string          // Mount volumes from the specified container(s).
-	SecurityOpt      []string          // Security options (e.g., "apparmor:unconfined", "seccomp=unconfined").
-	Sysctls          map[string]string // Kernel parameters (sysctls) to set in the container.
-	DNSServers       []string          // Custom DNS servers for the container.
-	DNSSearchDomains []string          // Custom DNS search domains for the container.
+	ImageName        string
+	ContainerName    string
+	Ports            []ContainerPortMapping
+	Volumes          []ContainerMount
+	EnvVars          []string
+	Command          []string
+	Entrypoint       []string
+	WorkingDir       string
+	User             string
+	RestartPolicy    string
+	NetworkMode      string
+	ExtraHosts       []string
+	Labels           map[string]string
+	Privileged       bool
+	CapAdd           []string
+	CapDrop          []string
+	Resources        ContainerResources
+	HealthCheck      *ContainerHealthCheck
+	AutoRemove       bool
+	VolumesFrom      []string
+	SecurityOpt      []string
+	Sysctls          map[string]string
+	DNSServers       []string
+	DNSSearchDomains []string
 }
 
-// ContainerResources defines CPU and memory constraints for a container.
 type ContainerResources struct {
-	CPUShares   int64  // Relative CPU shares (weight).
-	Memory      int64  // Memory limit in bytes (0 for unlimited).
-	NanoCPUs    int64  // CPU quota in units of 1e-9 CPUs (e.g., 0.5 CPUs = 500,000,000).
-	PidsLimit   int64  // PID limit for the container (Linux only). 0 or -1 for unlimited (kernel default may vary).
-	BlkioWeight uint16 // Block IO weight (relative weight), range 10 to 1000. 0 to disable.
+	CPUShares   int64
+	Memory      int64
+	NanoCPUs    int64
+	PidsLimit   int64
+	BlkioWeight uint16
 }
 
-// ContainerHealthCheck defines health check parameters for a container.
 type ContainerHealthCheck struct {
-	Test        []string      // Command to run to check health (e.g., ["CMD", "curl", "-f", "http://localhost/health"]).
-	Interval    time.Duration // Time between running the check.
-	Timeout     time.Duration // Maximum time to allow one check to run.
-	Retries     int           // Number of consecutive failures needed to consider the container unhealthy.
-	StartPeriod time.Duration // Start period for the container to initialize before health checks begin counting retries.
+	Test        []string
+	Interval    time.Duration
+	Timeout     time.Duration
+	Retries     int
+	StartPeriod time.Duration
 }
 
-
-// ContainerInfo holds basic information about a Docker container, typically from a list operation.
 type ContainerInfo struct {
-	ID      string   // ID of the container.
-	Names   []string // Names associated with the container.
-	Image   string   // Image name used to create the container.
-	ImageID string   // ID of the image.
-	Command string   // Command being run.
-	Created int64    // Unix timestamp of container creation time.
-	State   string   // Current state of the container (e.g., "running", "exited", "created").
-	Status  string   // Additional status information (e.g., "Up 2 hours", "Exited (0) 5 minutes ago").
-	Ports   []ContainerPortMapping // Port mappings active for the container.
-	Labels  map[string]string    // Labels applied to the container.
-	Mounts  []ContainerMount     // Mounts configured for the container.
+	ID      string
+	Names   []string
+	Image   string
+	ImageID string
+	Command string
+	Created int64
+	State   string
+	Status  string
+	Ports   []ContainerPortMapping
+	Labels  map[string]string
+	Mounts  []ContainerMount
 }
 
-// ContainerLogOptions specifies how to retrieve logs from a container.
 type ContainerLogOptions struct {
-	Follow     bool   // If true, stream logs. Note: string return type of GetContainerLogs is not ideal for Follow=true.
-	Tail       string // Number of lines to show from the end of the logs (e.g., "all", "100").
-	Since      string // Show logs since a specific timestamp (e.g., "2013-01-02T13:23:37Z") or relative duration (e.g., "42m").
-	Until      string // Show logs before a specific timestamp or relative duration.
-	Timestamps bool   // If true, include timestamps in log output.
-	Details    bool   // If true, show extra details provided to logs (rarely used, driver-dependent).
-	ShowStdout bool   // If true, retrieve stdout logs. Defaults to false if neither stdout/stderr is true.
-	ShowStderr bool   // If true, retrieve stderr logs. Defaults to false if neither stdout/stderr is true.
+	Follow     bool
+	Tail       string
+	Since      string
+	Until      string
+	Timestamps bool
+	Details    bool
+	ShowStdout bool
+	ShowStderr bool
 }
 
-// ContainerStats holds live resource usage statistics for a container.
 type ContainerStats struct {
-	CPUPercentage    float64 // Calculated CPU usage percentage across all cores.
-	MemoryUsageBytes uint64  // Current memory usage in bytes.
-	MemoryLimitBytes uint64  // Memory limit for the container in bytes.
-	NetworkRxBytes   uint64  // Cumulative network bytes received across all interfaces.
-	NetworkTxBytes   uint64  // Cumulative network bytes transmitted across all interfaces.
-	BlockReadBytes   uint64  // Cumulative block I/O bytes read from block devices.
-	BlockWriteBytes  uint64  // Cumulative block I/O bytes written to block devices.
-	PidsCurrent      uint64  // Current number of PIDs (processes/threads) in the container.
-	Error            error   // Used to propagate errors from the stats stream itself (e.g., decoding error).
+	CPUPercentage    float64
+	MemoryUsageBytes uint64
+	MemoryLimitBytes uint64
+	NetworkRxBytes   uint64
+	NetworkTxBytes   uint64
+	BlockReadBytes   uint64
+	BlockWriteBytes  uint64
+	PidsCurrent      uint64
+	Error            error
 }
 
-// ContainerDetails provides detailed information about a container, typically from an "inspect" operation.
-// This is a simplified representation; Docker's inspect output is very rich.
 type ContainerDetails struct {
-	ID              string    // Full ID of the container.
-	Created         string    // Timestamp of container creation.
-	Path            string    // Path to the command being run.
-	Args            []string  // Arguments to the command.
-	State           *ContainerState // Detailed state of the container.
-	Image           string    // Image ID (sha256 hash) the container was created from.
-	ResolvConfPath  string    // Path to the container's resolv.conf file.
-	HostnamePath    string    // Path to the container's hostname file.
-	HostsPath       string    // Path to the container's hosts file.
-	LogPath         string    // Path to the container's log file (driver-dependent).
-	Name            string    // Name of the container.
-	RestartCount    int       // Number of times the container has been restarted.
-	Driver          string    // Storage driver used for the container.
-	Platform        string    // Platform of the container (e.g., "linux").
-	MountLabel      string    // Mount label for SELinux.
-	ProcessLabel    string    // Process label for SELinux.
-	AppArmorProfile string    // AppArmor profile name.
-	ExecIDs         []string  // List of exec instance IDs running in the container.
-	HostConfig      *HostConfig // Host-specific configuration applied to the container.
-	GraphDriver     *GraphDriverData // Information about the storage driver.
-	Mounts          []ContainerMount // List of mounts configured for the container (reflects actual runtime mounts).
-	Config          *ContainerConfig // Container's base configuration as provided at creation time.
-	NetworkSettings *NetworkSettings // Network settings for the container, including IP addresses and connected networks.
+	ID              string
+	Created         string
+	Path            string
+	Args            []string
+	State           *ContainerState
+	Image           string
+	ResolvConfPath  string
+	HostnamePath    string
+	HostsPath       string
+	LogPath         string
+	Name            string
+	RestartCount    int
+	Driver          string
+	Platform        string
+	MountLabel      string
+	ProcessLabel    string
+	AppArmorProfile string
+	ExecIDs         []string
+	HostConfig      *HostConfig
+	GraphDriver     *GraphDriverData
+	Mounts          []ContainerMount
+	Config          *ContainerConfig
+	NetworkSettings *NetworkSettings
 }
 
-// ContainerState holds detailed information about a container's state.
 type ContainerState struct {
-	Status     string // Human-readable status (e.g., "running", "exited", "paused").
-	Running    bool   // True if the container is currently running.
-	Paused     bool   // True if the container is paused.
-	Restarting bool   // True if the container is in the process of restarting.
-	OOMKilled  bool   // True if the container was killed by OOM killer.
-	Dead       bool   // True if the container is dead (Docker internal state).
-	Pid        int    // Process ID of the container's main process on the host.
-	ExitCode   int    // Exit code of the container if it has exited.
-	Error      string // Error message if the container failed to start.
-	StartedAt  string // Timestamp when the container was last started.
-	FinishedAt string // Timestamp when the container last finished.
+	Status     string
+	Running    bool
+	Paused     bool
+	Restarting bool
+	OOMKilled  bool
+	Dead       bool
+	Pid        int
+	ExitCode   int
+	Error      string
+	StartedAt  string
+	FinishedAt string
 }
 
-// HostConfig is a simplified representation of Docker's HostConfig structure,
-// containing host-specific configurations for a container.
 type HostConfig struct {
-	NetworkMode   string // Network mode for the container.
-	RestartPolicy struct { // Restart policy.
-		Name              string // Policy name (e.g., "on-failure").
-		MaximumRetryCount int    // Max number of retries for "on-failure".
+	NetworkMode   string
+	RestartPolicy struct {
+		Name              string
+		MaximumRetryCount int
 	}
-	PortBindings map[string][]ContainerPortMapping // Port bindings. Key: "containerPort/protocol".
-	Resources    ContainerResources // Resource constraints.
-	Privileged   bool // True if container runs in privileged mode.
-	AutoRemove   bool // True if container should be removed on exit.
-	// Add other commonly used fields from Docker's HostConfig as needed.
-	// e.g., Binds, CapAdd, CapDrop, SecurityOpt, etc.
+	PortBindings map[string][]ContainerPortMapping
+	Resources    ContainerResources
+	Privileged   bool
+	AutoRemove   bool
 }
 
-// GraphDriverData holds information about the storage driver used for a container.
 type GraphDriverData struct {
-	Name string            // Name of the storage driver.
-	Data map[string]string // Driver-specific data.
+	Name string
+	Data map[string]string
 }
 
-// ContainerConfig is a simplified representation of Docker's container configuration,
-// as provided at creation time.
 type ContainerConfig struct {
-	Hostname     string   // Hostname of the container.
-	Domainname   string   // Domain name for the container.
-	User         string   // User that commands run as inside the container.
-	AttachStdin  bool     // True if stdin is attached.
-	AttachStdout bool     // True if stdout is attached.
-	AttachStderr bool     // True if stderr is attached.
-	ExposedPorts map[string]struct{} // Ports exposed by the Dockerfile (e.g. "80/tcp": {}).
-	Tty          bool     // True if a TTY is allocated.
-	OpenStdin    bool     // True if stdin is kept open even if not attached.
-	StdinOnce    bool     // True if stdin is closed after the first write.
-	Env          []string // Environment variables.
-	Cmd          []string // Command to run.
-	Image        string   // Image name specified at create time (not the ID).
-	Volumes      map[string]struct{} // Volumes defined in the Dockerfile (e.g. "/var/www": {}).
-	WorkingDir   string   // Working directory.
-	Entrypoint   []string // Entrypoint.
-	Labels       map[string]string // Labels.
-	Healthcheck  *ContainerHealthCheck // Healthcheck configuration from Dockerfile or create options.
+	Hostname     string
+	Domainname   string
+	User         string
+	AttachStdin  bool
+	AttachStdout bool
+	AttachStderr bool
+	ExposedPorts map[string]struct{}
+	Tty          bool
+	OpenStdin    bool
+	StdinOnce    bool
+	Env          []string
+	Cmd          []string
+	Image        string
+	Volumes      map[string]struct{}
+	WorkingDir   string
+	Entrypoint   []string
+	Labels       map[string]string
+	Healthcheck  *ContainerHealthCheck
 }
 
-// NetworkSettings holds detailed network configuration and runtime state for a container.
 type NetworkSettings struct {
-	Bridge                 string   // Name of the bridge interface on the host if using default bridge network.
-	SandboxID              string   // ID of the network sandbox.
-	HairpinMode            bool     // True if hairpin NAT is enabled.
-	LinkLocalIPv6Address   string   // IPv6 link-local address.
-	LinkLocalIPv6PrefixLen int      // Prefix length for IPv6 link-local address.
-	Ports                  map[string][]ContainerPortMapping // Runtime port mappings.
-	SandboxKey             string   // Key for the network sandbox.
-	SecondaryIPAddresses   []string // Array of secondary IPv4 addresses.
-	SecondaryIPv6Addresses []string // Array of secondary IPv6 addresses.
-	EndpointID             string   // ID of the container's endpoint in the default network.
-	Gateway                string   // Gateway IP address for the default network.
-	GlobalIPv6Address      string   // Global IPv6 address.
-	GlobalIPv6PrefixLen    int      // Prefix length for global IPv6 address.
-	IPAddress              string   // IPv4 address in the default network.
-	IPPrefixLen            int      // Prefix length for IPv4 address.
-	IPv6Gateway            string   // IPv6 gateway address.
-	MacAddress             string   // MAC address for the default network interface.
-	Networks               map[string]*EndpointSettings // Network settings for each network the container is connected to, keyed by network name or ID.
+	Bridge                 string
+	SandboxID              string
+	HairpinMode            bool
+	LinkLocalIPv6Address   string
+	LinkLocalIPv6PrefixLen int
+	Ports                  map[string][]ContainerPortMapping
+	SandboxKey             string
+	SecondaryIPAddresses   []string
+	SecondaryIPv6Addresses []string
+	EndpointID             string
+	Gateway                string
+	GlobalIPv6Address      string
+	GlobalIPv6PrefixLen    int
+	IPAddress              string
+	IPPrefixLen            int
+	IPv6Gateway            string
+	MacAddress             string
+	Networks               map[string]*EndpointSettings
 }
 
-// EndpointSettings holds configuration for a container's network endpoint in a specific network.
 type EndpointSettings struct {
-	IPAMConfig          *EndpointIPAMConfig // IPAM configuration for this endpoint.
-	Links               []string // Links to other containers in this network.
-	Aliases             []string // Aliases for this container in this network.
-	NetworkID           string   // ID of the network.
-	EndpointID          string   // ID of this endpoint.
-	Gateway             string   // Gateway IP address for this network.
-	IPAddress           string   // IPv4 address in this network.
-	IPPrefixLen         int      // Prefix length for IPv4 address in this network.
-	IPv6Gateway         string   // IPv6 gateway address for this network.
-	GlobalIPv6Address   string   // Global IPv6 address in this network.
-	GlobalIPv6PrefixLen int      // Prefix length for global IPv6 address.
-	MacAddress          string   // MAC address for this endpoint.
-	DriverOpts          map[string]string // Driver-specific options for this endpoint.
+	IPAMConfig          *EndpointIPAMConfig
+	Links               []string
+	Aliases             []string
+	NetworkID           string
+	EndpointID          string
+	Gateway             string
+	IPAddress           string
+	IPPrefixLen         int
+	IPv6Gateway         string
+	GlobalIPv6Address   string
+	GlobalIPv6PrefixLen int
+	MacAddress          string
+	DriverOpts          map[string]string
 }
 
-// EndpointIPAMConfig holds IPAM (IP Address Management) configuration for a network endpoint.
 type EndpointIPAMConfig struct {
-	IPv4Address  string   // Static IPv4 address.
-	IPv6Address  string   // Static IPv6 address.
-	LinkLocalIPs []string // List of link-local IP addresses.
+	IPv4Address  string
+	IPv6Address  string
+	LinkLocalIPs []string
 }
 
-
-// DockerNetworkInfo holds information about a Docker network.
 type DockerNetworkInfo struct {
-	ID         string   // ID of the network.
-	Name       string   // Name of the network.
-	Driver     string   // Driver used for the network (e.g., "bridge", "overlay").
-	Scope      string   // Scope of the network (e.g., "local", "swarm", "global").
-	EnableIPv6 bool     // True if IPv6 is enabled on this network.
-	Subnets    []string // List of subnets in CIDR format associated with this network's IPAM configurations.
-	Gateways   []string // List of gateways associated with this network's IPAM configurations.
-	Containers map[string]string // Map of container ID to container name for containers connected to this network.
+	ID         string
+	Name       string
+	Driver     string
+	Scope      string
+	EnableIPv6 bool
+	Subnets    []string
+	Gateways   []string
+	Containers map[string]string
 }
 
-// DockerVolumeInfo holds information about a Docker volume.
 type DockerVolumeInfo struct {
-	Name       string            // Name of the volume.
-	Driver     string            // Driver used for the volume (e.g., "local").
-	Mountpoint string            // Path on the host where the volume data is stored.
-	Labels     map[string]string // Labels applied to the volume.
-	Scope      string            // Scope of the volume (e.g., "local", "global").
+	Name       string
+	Driver     string
+	Mountpoint string
+	Labels     map[string]string
+	Scope      string
 }
 
-// DockerVolumeDetails provides detailed information about a Docker volume, typically from an "inspect" operation.
 type DockerVolumeDetails struct {
-	Name       string            // Name of the volume.
-	Driver     string            // Driver used for the volume.
-	Mountpoint string            // Path on the host where the volume data is stored.
-	Status     map[string]string // Driver-specific status information (can be nil).
-	Labels     map[string]string // Labels applied to the volume.
-	Scope      string            // Scope of the volume.
-	Options    map[string]string // Driver options used when the volume was created.
-	CreatedAt  string            // Timestamp of when the volume was created.
+	Name       string
+	Driver     string
+	Mountpoint string
+	Status     map[string]string
+	Labels     map[string]string
+	Scope      string
+	Options    map[string]string
+	CreatedAt  string
 }
 
-// DockerSystemInfo holds general information about the Docker daemon.
-// This is a selection of fields commonly found in the output of `docker info`.
 type DockerSystemInfo struct {
-	ID                string      // Unique ID of the Docker daemon.
-	Containers        int         // Total number of containers managed by the daemon.
-	ContainersRunning int         // Number of containers currently running.
-	ContainersPaused  int         // Number of containers currently paused.
-	ContainersStopped int         // Number of containers currently stopped.
-	Images            int         // Total number of images known to the daemon.
-	Driver            string      // Storage driver being used (e.g., "overlay2", "aufs").
-	DriverStatus      [][2]string // Key-value pairs describing the status of the storage driver.
-	Plugins           struct {    // Information about installed plugins.
-		Volume  []string // List of volume plugin names.
-		Network []string // List of network plugin names.
-		// Add other plugin types as needed (e.g., Authorization, Log)
+	ID                string
+	Containers        int
+	ContainersRunning int
+	ContainersPaused  int
+	ContainersStopped int
+	Images            int
+	Driver            string
+	DriverStatus      [][2]string
+	Plugins           struct {
+		Volume  []string
+		Network []string
 	}
-	MemoryLimit       bool   // True if memory limit support is enabled for containers.
-	SwapLimit         bool   // True if swap limit support is enabled for containers.
-	KernelMemory      bool   // True if kernel memory limit support is enabled (deprecated, use KernelMemoryTCP).
-	CPUCfsPeriod      bool   // True if CPU CFS period support is enabled.
-	CPUCfsQuota       bool   // True if CPU CFS quota support is enabled.
-	CPUShares         bool   // True if CPU shares support is enabled.
-	CPUSet            bool   // True if CPU set support (pinning to specific CPUs) is enabled.
-	PidsLimit         bool   // True if PIDs limit support for containers is enabled.
-	IPv4Forwarding    bool   // True if IPv4 forwarding is enabled on the host.
-	BridgeNfIptables  bool   // True if bridge netfilter iptables is enabled (required for Docker networking).
-	BridgeNfIp6tables bool   // True if bridge netfilter ip6tables is enabled.
-	Debug             bool   // True if the Docker daemon is running in debug mode.
-	NFd               int    // Number of file descriptors currently used by the daemon process.
-	OomKillDisable    bool   // True if OOM kill disable support is enabled for containers.
-	NGoroutines       int    // Number of active goroutines in the daemon process.
-	SystemTime        string // Current system time on the daemon host, in RFC3339Nano format.
-	LoggingDriver     string // Default logging driver for containers (e.g., "json-file").
-	CgroupDriver      string // Cgroup driver used by the daemon (e.g., "cgroupfs", "systemd").
-	CgroupVersion     string // Cgroup version in use by the host system (e.g., "1", "2").
-	NEventsListener   int    // Number of event listeners registered with the daemon.
-	KernelVersion     string // Kernel version of the host operating system.
-	OperatingSystem   string // Operating system of the host (e.g., "Docker Desktop", "Ubuntu 20.04.3 LTS").
-	OSType            string // OS type (e.g., "linux", "windows").
-	Architecture      string // Hardware architecture of the host (e.g., "x86_64", "aarch64").
-	IndexServerAddress string // Default registry server address (usually "https://index.docker.io/v1/").
-	RegistryConfig    *RegistryConfig // Information about configured Docker registries, including mirrors and insecure registries.
-	NCPU              int    // Number of logical CPUs available to the daemon.
-	MemTotal          int64  // Total physical memory on the host in bytes.
-	ServerVersion     string // Version of the Docker server (daemon).
-	// Add more fields as needed from `docker info` (e.g. SecurityOptions, Runtimes, LiveRestoreEnabled).
+	MemoryLimit       bool
+	SwapLimit         bool
+	KernelMemory      bool
+	CPUCfsPeriod      bool
+	CPUCfsQuota       bool
+	CPUShares         bool
+	CPUSet            bool
+	PidsLimit         bool
+	IPv4Forwarding    bool
+	BridgeNfIptables  bool
+	BridgeNfIp6tables bool
+	Debug             bool
+	NFd               int
+	OomKillDisable    bool
+	NGoroutines       int
+	SystemTime        string
+	LoggingDriver     string
+	CgroupDriver      string
+	CgroupVersion     string
+	NEventsListener   int
+	KernelVersion     string
+	OperatingSystem   string
+	OSType            string
+	Architecture      string
+	IndexServerAddress string
+	RegistryConfig    *RegistryConfig
+	NCPU              int
+	MemTotal          int64
+	ServerVersion     string
 }
 
-// RegistryConfig mirrors parts of the Docker daemon's registry configuration,
-// such as mirrors and insecure registry settings.
 type RegistryConfig struct {
-	IndexConfigs map[string]*IndexInfo // Configuration for specific registry indexes, keyed by registry hostname (e.g., "docker.io").
-	// InsecureRegistryCIDRs, etc. can be added if detailed insecure registry info is needed.
+	IndexConfigs map[string]*IndexInfo
 }
 
-// IndexInfo holds information about a specific Docker registry index, including its mirrors and security status.
 type IndexInfo struct {
-	Name     string   // Name of the registry (e.g., "docker.io").
-	Mirrors  []string // List of configured mirror URLs for this registry.
-	Secure   bool     // True if the registry is considered secure (HTTPS with valid certificate). Note: This model's `Secure` is inverted from Docker API's `Secure` field.
-	Official bool     // True if this is an official Docker registry (e.g., Docker Hub).
+	Name     string
+	Mirrors  []string
+	Secure   bool
+	Official bool
 }
 
-
-// VMNetworkInterface defines network interface parameters for a VM
 type VMNetworkInterface struct {
-	Type       string // e.g., "network", "bridge", "direct"
-	Source     string // e.g., "default" (libvirt network), "br0" (bridge name), "eth0" (direct interface)
-	Model      string // e.g., "virtio"
-	MACAddress string // Optional, specific MAC address
+	Type       string
+	Source     string
+	Model      string
+	MACAddress string
 }
 
-// VMInfo holds basic information about a virtual machine
 type VMInfo struct {
 	Name   string
-	State  string // e.g., "running", "shut off", "paused"
+	State  string
 	CPUs   int
-	Memory uint // in MB
+	Memory uint
 	UUID   string
 }
 
-
-// UserModifications defines the set of attributes that can be changed for a user.
-// Pointers are used for string fields to distinguish between a requested empty value (not usually applicable for these fields)
-// and a value that should not be changed (nil pointer).
 type UserModifications struct {
-	NewUsername         *string  // New login name (-l NEW_LOGIN)
-	NewPrimaryGroup     *string  // New primary group name or GID (-g GROUP)
-	AppendToGroups      []string // Groups to add the user to (appends to existing secondary groups -aG GROUP1,GROUP2)
-	SetSecondaryGroups  []string // Explicitly set secondary groups (replaces all existing secondary groups -G GROUP1,GROUP2)
-	NewShell            *string  // New login shell (-s SHELL)
-	NewHomeDir          *string  // New home directory path (-d HOME_DIR)
-	MoveHomeDirContents bool     // If NewHomeDir is set, move contents from old home to new home (requires -m flag with -d)
-	NewComment          *string  // New GECOS comment field (-c COMMENT)
-	LockPassword        bool     // Lock the user's password (-L)
-	UnlockPassword      bool     // Unlock the user's password (-U)
-	ExpireDate          *string  // Set password expiration date YYYY-MM-DD (-e EXPIRE_DATE)
+	NewUsername         *string
+	NewPrimaryGroup     *string
+	AppendToGroups      []string
+	SetSecondaryGroups  []string
+	NewShell            *string
+	NewHomeDir          *string
+	MoveHomeDirContents bool
+	NewComment          *string
+	LockPassword        bool
+	UnlockPassword      bool
+	ExpireDate          *string
 }
 
-// UserInfo holds detailed information about a user.
 type UserInfo struct {
 	Username string
 	UID      string
 	GID      string
-	Comment  string   // GECOS field
+	Comment  string
 	HomeDir  string
 	Shell    string
-	Groups   []string // List of group names the user belongs to
-	PasswordStatus string // e.g. P (Passworded), L (Locked), NP (No Password)
+	Groups   []string
+	PasswordStatus string
 }
-
-// --- QEMU/libvirt Supporting Structs (Continued) ---
 
 type VMNetworkInterfaceDetail struct {
 	VMNetworkInterface
-	InterfaceName string // e.g., vnet0, macvtap0
-	State         string // e.g., active, inactive
-	// Other details like RX/TX bytes could be added if virsh domiflist provides them easily
+	InterfaceName string
+	State         string
 }
 
 type VMSnapshotDiskSpec struct {
-	Name       string // Disk name (e.g., vda, sdb)
-	Snapshot   string // "internal", "external", "no" (default: "internal")
-	DriverType string // e.g., "qcow2" (only if snapshot=external)
-	File       string // Path for external snapshot file (only if snapshot=external)
+	Name       string
+	Snapshot   string
+	DriverType string
+	File       string
 }
 
 type VMSnapshotInfo struct {
 	Name        string
 	Description string
-	CreatedAt   string // Timestamp
-	State       string // e.g., "running", "shutoff", "disk-snapshot"
+	CreatedAt   string
+	State       string
 	HasParent   bool
-	Children    []string // Names of child snapshots
-	Disks       map[string]string // Disk name -> snapshot type/file
+	Children    []string
+	Disks       map[string]string
 }
 
 type VMInterfaceAddress struct {
@@ -1758,48 +1460,45 @@ type VMInterfaceAddress struct {
 type VMInterfaceInfo struct {
 	Name          string               `json:"name"`
 	MAC           string               `json:"mac"`
-	Source        string               `json:"source,omitempty"` // e.g. bridge name for bridged interfaces
-	IPAddresses   []VMInterfaceAddress `json:"ip-addresses,omitempty"` // From guest agent if available
+	Source        string               `json:"source,omitempty"`
+	IPAddresses   []VMInterfaceAddress `json:"ip-addresses,omitempty"`
 }
 
 type VMBlockDeviceInfo struct {
-	Device     string `json:"device"`      // e.g. "vda"
-	Type       string `json:"type"`        // e.g. "file", "block"
-	SourceFile string `json:"source-file,omitempty"` // Path to image file
-	DriverType string `json:"driver-type,omitempty"` // e.g. "qcow2"
-	TargetBus  string `json:"target-bus,omitempty"` // e.g. "virtio"
-	Size       uint64 `json:"size-bytes,omitempty"` // From guest agent or qemu-img info
+	Device     string `json:"device"`
+	Type       string `json:"type"`
+	SourceFile string `json:"source-file,omitempty"`
+	DriverType string `json:"driver-type,omitempty"`
+	TargetBus  string `json:"target-bus,omitempty"`
+	Size       uint64 `json:"size-bytes,omitempty"`
 }
 
 
 type VMDetails struct {
-	VMInfo             // Embeds basic info
+	VMInfo
 	OSVariant          string
-	DomainType         string // e.g. "kvm", "qemu"
+	DomainType         string
 	Architecture       string
 	EmulatorPath       string
 	Graphics           []VMGraphicsInfo
 	Disks              []VMBlockDeviceInfo
-	NetworkInterfaces  []VMInterfaceInfo // More detailed than VMNetworkInterface
+	NetworkInterfaces  []VMInterfaceInfo
 	PersistentConfig   bool
 	Autostart          bool
-	EffectiveMemory    uint // Current memory in MB, if different from configured
-	EffectiveVCPUs     uint // Current vCPUs, if different
-	RawXML             string // Full XML definition
+	EffectiveMemory    uint
+	EffectiveVCPUs     uint
+	RawXML             string
 }
 
 type VMGraphicsInfo struct {
-	Type     string // e.g. "vnc", "spice"
+	Type     string
 	Port     string
 	Listen   string
-	Password string // Might be "yes" or "no" if set/not set
+	Password string
 	Keymap   string
 }
 
-
-// --- Containerd/crictl Supporting Structs (Continued) ---
-
-type CrictlRuntimeInfo struct { // For `crictl info` output
+type CrictlRuntimeInfo struct {
 	Config struct {
 		Containerd struct {
 			Snapshotter string `json:"snapshotter"`
@@ -1810,124 +1509,121 @@ type CrictlRuntimeInfo struct { // For `crictl info` output
 				SandboxMode   string `json:"sandboxMode"`
 			} `json:"runtimes"`
 		} `json:"containerd"`
-		// Other fields like CNI config, etc.
 	} `json:"config"`
-	Status map[string]interface{} `json:"status"` // Runtime specific status
+	Status map[string]interface{} `json:"status"`
 }
 
-// --- Kubectl Supporting Structs (Continued) ---
-
 type KubectlTopOptions struct {
-	KubeconfigPath string   // Path to kubeconfig file
-	Namespace      string   // Namespace for "top pod"
-	AllNamespaces  bool     // If true, "top pod" from all namespaces
-	Selector       string   // Selector (label query) to filter pods/nodes
-	Containers     bool     // For "top pod", show container metrics
-	SortBy         string   // cpu|memory
-	UseHeapster    bool     // Use Heapster to get metrics
+	KubeconfigPath string
+	Namespace      string
+	AllNamespaces  bool
+	Selector       string
+	Containers     bool
+	SortBy         string
+	UseHeapster    bool
 	Sudo           bool
 }
 
 type KubectlExplainOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	APIVersion     string // API version for the resource e.g. "apps/v1"
-	Recursive      bool   // Print the fields of fields recursively
+	KubeconfigPath string
+	APIVersion     string
+	Recursive      bool
 	Sudo           bool
 }
 
 type KubectlDrainOptions struct {
-	KubeconfigPath      string        // Path to kubeconfig file
-	Force               bool          // Continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.
-	GracePeriod         int           // Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.
-	IgnoreDaemonSets    bool          // Ignore DaemonSet-managed pods.
-	DeleteLocalData     bool          // Even if there are pods using emptyDir (data won't be preserved), delete them.
-	Selector            string        // Selector (label query) to filter pods.
-	Timeout             time.Duration // The length of time to wait before giving up, zero means infinite
-	DisableEviction     bool          // Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets.
-	SkipWaitForDeleteTimeout int    // If pod DeletionTimestamp in the future, skip waiting for the pod.  Seconds before pod deletion. 0 means default behavior.
+	KubeconfigPath      string
+	Force               bool
+	GracePeriod         int
+	IgnoreDaemonSets    bool
+	DeleteLocalData     bool
+	Selector            string
+	Timeout             time.Duration
+	DisableEviction     bool
+	SkipWaitForDeleteTimeout int
 	Sudo                bool
 }
 
 type KubectlCordonUncordonOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	Selector       string // Selector (label query) to filter nodes
+	KubeconfigPath string
+	Selector       string
 	Sudo           bool
 }
 
 type KubectlTaintOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	Selector       string // Selector (label query) to filter nodes
-	Overwrite      bool   // If true, overwrite existing taints
-	All            bool   // Select all nodes in the cluster
+	KubeconfigPath string
+	Selector       string
+	Overwrite      bool
+	All            bool
 	Sudo           bool
 }
 
 type KubectlCreateOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	DryRun         string // "none", "client", or "server". Default "none".
-	Validate       bool   // Validate schemas. Default true.
+	KubeconfigPath string
+	DryRun         string
+	Validate       bool
 	Sudo           bool
 }
 
 type KubectlSetOptions struct {
-	KubeconfigPath string   // Path to kubeconfig file
-	Namespace      string   // Namespace for the resource
-	All            bool     // If true, select all resources
-	Selector       string   // Selector (label query) to filter resources
-	Local          bool     // If true, calculate the patch locally and print it. Do not send it to the server.
-	DryRun         string   // "none", "client", or "server". Default "none".
+	KubeconfigPath string
+	Namespace      string
+	All            bool
+	Selector       string
+	Local          bool
+	DryRun         string
 	Sudo           bool
 }
 
 type KubectlAutoscaleOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	Namespace      string // Namespace for the resource
-	Name           string // Name for the HPA object. If not specified, it's derived from the resource.
-	DryRun         string // "none", "client", or "server". Default "none".
+	KubeconfigPath string
+	Namespace      string
+	Name           string
+	DryRun         string
 	Sudo           bool
 }
 
 type KubectlWaitOptions struct {
-	KubeconfigPath string        // Path to kubeconfig file
-	Namespace      string        // Namespace for the resource
-	AllNamespaces  bool          // If true, wait for resources in all namespaces
-	Selector       string        // Selector (label query) to filter resources
-	FieldSelector  string        // Selector (field query) to filter resources
-	For            string        // The condition to wait on: "delete", "jsonpath={...}", "condition=..."
-	Timeout        time.Duration // How long to wait before giving up
+	KubeconfigPath string
+	Namespace      string
+	AllNamespaces  bool
+	Selector       string
+	FieldSelector  string
+	For            string
+	Timeout        time.Duration
 	Sudo           bool
 }
 
 type KubectlLabelOptions struct {
-	KubeconfigPath string        // Path to kubeconfig file
-	Namespace      string        // Namespace for the resource
-	AllNamespaces  bool          // If true, operate on resources in all namespaces
-	Selector       string        // Selector (label query) to filter resources
-	Overwrite      bool          // If true, allow labels to be overwritten
-	Local          bool          // If true, calculate the patch locally and print it.
-	DryRun         string        // "none", "client", or "server". Default "none".
-	ListLabels     bool          // If true, list the labels for a resource or resources
-	Timeout        time.Duration // Timeout for the operation
+	KubeconfigPath string
+	Namespace      string
+	AllNamespaces  bool
+	Selector       string
+	Overwrite      bool
+	Local          bool
+	DryRun         string
+	ListLabels     bool
+	Timeout        time.Duration
 	Sudo           bool
 }
 
 type KubectlAnnotateOptions struct {
-	KubeconfigPath string        // Path to kubeconfig file
-	Namespace      string        // Namespace for the resource
-	AllNamespaces  bool          // If true, operate on resources in all namespaces
-	Selector       string        // Selector (label query) to filter resources
-	Overwrite      bool          // If true, allow annotations to be overwritten
-	Local          bool          // If true, calculate the patch locally and print it.
-	DryRun         string        // "none", "client", or "server". Default "none".
-	ListAnnotations bool         // If true, list the annotations for a resource or resources
-	Timeout        time.Duration // Timeout for the operation
+	KubeconfigPath string
+	Namespace      string
+	AllNamespaces  bool
+	Selector       string
+	Overwrite      bool
+	Local          bool
+	DryRun         string
+	ListAnnotations bool
+	Timeout        time.Duration
 	Sudo           bool
 }
 
 type KubectlPatchOptions struct {
-	KubeconfigPath string // Path to kubeconfig file
-	Namespace      string // Namespace for the resource
-	Local          bool   // If true, calculate the patch locally and print it.
-	DryRun         string // "none", "client", or "server". Default "none".
+	KubeconfigPath string
+	Namespace      string
+	Local          bool
+	DryRun         string
 	Sudo           bool
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -377,12 +377,6 @@ func (r *defaultRunner) Reboot(ctx context.Context, conn connector.Connector, ti
 // or its specialized files (like archive.go, file.go, etc.).
 
 // --- QEMU/libvirt Methods ---
-func (r *defaultRunner) CreateVMTemplate(ctx context.Context, conn connector.Connector, name string, osVariant string, memoryMB uint, vcpus uint, diskPath string, diskSizeGB uint, network string, graphicsType string, cloudInitISOPath string) error {
-	return fmt.Errorf("not implemented: CreateVMTemplate")
-}
-func (r *defaultRunner) ImportVMTemplate(ctx context.Context, conn connector.Connector, name string, filePath string) error {
-	return fmt.Errorf("not implemented: ImportVMTemplate")
-}
 func (r *defaultRunner) RefreshStoragePool(ctx context.Context, conn connector.Connector, poolName string) error {
 	return fmt.Errorf("not implemented: RefreshStoragePool")
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,0 +1,23 @@
+package util
+
+import "strings"
+
+// ShellEscape provides basic shell escaping for a string.
+// WARNING: This is a simplified version and may not cover all edge cases.
+// For production use, a more robust library or approach might be needed if paths can be arbitrary.
+func ShellEscape(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// StrPtr returns a pointer to the string value s.
+func StrPtr(s string) *string {
+	return &s
+}
+
+// BoolPtr returns a pointer to the bool value b.
+func BoolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
Known issues:
- Project does not build.
- Persistent errors with 'undefined' structs in pkg/runner/interface.go despite overwrite attempts.
- Persistent errors with 'redeclared' helper functions (shellEscape, strPtr, boolPtr) despite attempts to centralize.
- Likely redeclared test functions in pkg/runner/containerd_test.go.
- Likely redeclared method stubs in pkg/runner/runner.go conflicting with implementations in specialized files (e.g., qemu.go).