### PR TITLE
Refactor health checks to use for-select-ticker

### DIFF
--- a/pkg/step/kubernetes/kube-scheduler/check_scheduler_health.go
+++ b/pkg/step/kubernetes/kube-scheduler/check_scheduler_health.go
@@ -12,7 +12,6 @@ import (
 type CheckSchedulerHealthStep struct {
 	step.Base
 	HealthCheckURL string
-	RetryCount     int
 	RetryDelay     time.Duration
 }
 
@@ -23,7 +22,6 @@ type CheckSchedulerHealthStepBuilder struct {
 func NewCheckSchedulerHealthStepBuilder(ctx runtime.Context, instanceName string) *CheckSchedulerHealthStepBuilder {
 	s := &CheckSchedulerHealthStep{
 		HealthCheckURL: "https://127.0.0.1:10259/healthz",
-		RetryCount:     12,
 		RetryDelay:     5 * time.Second,
 	}
 
@@ -81,26 +79,32 @@ func (s *CheckSchedulerHealthStep) Precheck(ctx runtime.ExecutionContext) (isDon
 
 func (s *CheckSchedulerHealthStep) Run(ctx runtime.ExecutionContext) error {
 	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	logger.Info("Waiting for kube-scheduler to be healthy...")
 
-	for i := 0; i < s.RetryCount; i++ {
-		logger.Infof("Waiting for kube-scheduler to be healthy... (Attempt %d/%d)", i+1, s.RetryCount)
+	timeout := time.After(s.Base.Timeout)
+	ticker := time.NewTicker(s.RetryDelay)
+	defer ticker.Stop()
 
-		healthy, err := s.checkHealth(ctx)
-		if healthy {
-			logger.Info("kube-scheduler is healthy!")
-			return nil
-		}
-
-		if err != nil {
-			logger.Debugf("Health check attempt failed: %v", err)
-		}
-
-		if i < s.RetryCount-1 {
-			time.Sleep(s.RetryDelay)
+	var lastErr error
+	for {
+		select {
+		case <-timeout:
+			if lastErr != nil {
+				return fmt.Errorf("kube-scheduler health check timed out after %v: %w", s.Base.Timeout, lastErr)
+			}
+			return fmt.Errorf("kube-scheduler health check timed out after %v", s.Base.Timeout)
+		case <-ticker.C:
+			healthy, err := s.checkHealth(ctx)
+			if healthy {
+				logger.Info("kube-scheduler is healthy!")
+				return nil
+			}
+			if err != nil {
+				lastErr = err
+				logger.Debugf("Health check attempt failed: %v", err)
+			}
 		}
 	}
-
-	return fmt.Errorf("kube-scheduler did not become healthy after %d attempts", s.RetryCount)
 }
 
 func (s *CheckSchedulerHealthStep) Rollback(ctx runtime.ExecutionContext) error {

--- a/pkg/step/pki/kubexm/check_kubelet_health.go
+++ b/pkg/step/pki/kubexm/check_kubelet_health.go
@@ -14,7 +14,6 @@ type VerifyKubeletHealthStep struct {
 	step.Base
 	serviceName     string
 	healthzEndpoint string
-	retries         int
 	retryDelay      time.Duration
 }
 
@@ -26,7 +25,6 @@ func NewVerifyKubeletHealthStepBuilder(ctx runtime.Context, instanceName string)
 	s := &VerifyKubeletHealthStep{
 		serviceName:     "kubelet",
 		healthzEndpoint: "http://127.0.0.1:10248/healthz",
-		retries:         12,
 		retryDelay:      10 * time.Second,
 	}
 	s.Base.Meta.Name = instanceName
@@ -64,24 +62,31 @@ func (s *VerifyKubeletHealthStep) Run(ctx runtime.ExecutionContext) error {
 	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
 	logger.Info("Verifying kubelet health...")
 
+	timeout := time.After(s.Base.Timeout)
+	ticker := time.NewTicker(s.retryDelay)
+	defer ticker.Stop()
+
 	var lastErr error
-	for i := 0; i < s.retries; i++ {
-		log := logger.With("attempt", i+1)
-		log.Infof("Attempting to verify kubelet health...")
+	for {
+		select {
+		case <-timeout:
+			if lastErr != nil {
+				return fmt.Errorf("kubelet health verification timed out after %v: %w", s.Base.Timeout, lastErr)
+			}
+			return fmt.Errorf("kubelet health verification timed out after %v", s.Base.Timeout)
+		case <-ticker.C:
+			logger.Info("Attempting to verify kubelet health...")
 
-		err := s.checkKubelet(ctx)
-		if err == nil {
-			logger.Info("kubelet is healthy.")
-			return nil
+			err := s.checkKubelet(ctx)
+			if err == nil {
+				logger.Info("kubelet is healthy.")
+				return nil
+			}
+
+			lastErr = err
+			logger.Warnf("Health check failed: %v. Retrying...", err)
 		}
-
-		lastErr = err
-		log.Warnf("Health check failed: %v. Retrying in %v...", err, s.retryDelay)
-		time.Sleep(s.retryDelay)
 	}
-
-	logger.Errorf("kubelet did not become healthy after %d retries.", s.retries)
-	return fmt.Errorf("kubelet health verification failed: %w", lastErr)
 }
 
 func (s *VerifyKubeletHealthStep) checkKubelet(ctx runtime.ExecutionContext) error {


### PR DESCRIPTION
This commit refactors several health check steps to use a more elegant `for select` loop with a `time.Ticker` and a timeout. This replaces the previous implementation that used a `for` loop with `time.Sleep`.

The new implementation is more idiomatic and robust. It also removes the now unused `retries` or `RetryCount` fields from the step structs.

The following files were refactored:
- pkg/step/etcd/check_cluster_health.go
- pkg/step/etcd/check_health.go
- pkg/step/etcd/check_single_health.go
- pkg/step/kubernetes/kube-apiserver/check_kube_apiserver_health.go
- pkg/step/kubernetes/kube-controller-manager/check_controller_manager_health.go
- pkg/step/kubernetes/kube-scheduler/check_scheduler_health.go
- pkg/step/pki/kubeadm/check_cluster_health.go
- pkg/step/pki/kubeadm/check_control_plane_health.go
- pkg/step/pki/kubeadm/check_etcd_cluster_health.go
- pkg/step/pki/kubeadm/check_etcd_pod_health.go
- pkg/step/pki/kubexm/check_apiserver_health.go
- pkg/step/pki/kubexm/check_kubelet_health.go

Additionally, a typo in the following filename was fixed:
- `pkg/step/pki/kubexm/check_apiserver_heath.go` -> `check_apiserver_health.go`

This work is a partial completion of a larger refactoring plan. The remaining health check files can be refactored in a future commit.