### PR TITLE
feat(step): Add missing lifecycle methods and improve idempotency

### DIFF
--- a/pkg/step/harbor/restart_harbor.go
+++ b/pkg/step/harbor/restart_harbor.go
@@ -1,0 +1,101 @@
+package harbor
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+	"github.com/mensylisir/kubexm/pkg/step/helpers/bom/binary"
+)
+
+type RestartHarborStep struct {
+	step.Base
+	RemoteInstallDir string
+}
+
+type RestartHarborStepBuilder struct {
+	step.Builder[RestartHarborStepBuilder, *RestartHarborStep]
+}
+
+func NewRestartHarborStepBuilder(ctx runtime.Context, instanceName string) *RestartHarborStepBuilder {
+	provider := binary.NewBinaryProvider(&ctx)
+	const representativeArch = "amd64"
+	binaryInfo, err := provider.GetBinary(binary.ComponentHarbor, representativeArch)
+
+	if err != nil || binaryInfo == nil {
+		return nil
+	}
+
+	cfg := ctx.GetClusterConfig().Spec
+	localCfg := cfg.Registry.LocalDeployment
+
+	if localCfg == nil || localCfg.Type != "harbor" {
+		return nil
+	}
+
+	installRoot := "/opt"
+	if localCfg.DataRoot != "" {
+		installRoot = localCfg.DataRoot
+	}
+
+	s := &RestartHarborStep{
+		RemoteInstallDir: filepath.Join(installRoot, "harbor"),
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Restart Harbor services on the registry node", s.Base.Meta.Name)
+	s.Base.Sudo = false
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 15 * time.Minute
+
+	b := new(RestartHarborStepBuilder).Init(s)
+	return b
+}
+
+func (s *RestartHarborStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *RestartHarborStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	// A restart operation should generally always run.
+	return false, nil
+}
+
+func (s *RestartHarborStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	composeFilePath := filepath.Join(s.RemoteInstallDir, "docker-compose.yml")
+	if exists, _ := runner.Exists(ctx.GoContext(), conn, composeFilePath); !exists {
+		logger.Warnf("Harbor docker-compose.yml not found at '%s', cannot restart.", composeFilePath)
+		return nil
+	}
+
+	restartCmd := fmt.Sprintf("cd %s && docker-compose restart", s.RemoteInstallDir)
+	logger.Infof("Executing Harbor restart command on remote host: %s", restartCmd)
+
+	output, err := runner.Run(ctx.GoContext(), conn, restartCmd, s.Sudo)
+	if err != nil {
+		logger.Errorf("Harbor restart failed. Full output:\n%s", output)
+		return fmt.Errorf("failed to execute docker-compose restart: %w", err)
+	}
+
+	logger.Info("Harbor services restarted successfully.")
+	logger.Debugf("Harbor restart output:\n%s", output)
+	return nil
+}
+
+func (s *RestartHarborStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	logger.Warn("Rollback for a restart step is a no-op.")
+	return nil
+}
+
+var _ step.Step = (*RestartHarborStep)(nil)

--- a/pkg/step/harbor/stop_harbor_service.go
+++ b/pkg/step/harbor/stop_harbor_service.go
@@ -1,0 +1,140 @@
+package harbor
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+	"github.com/mensylisir/kubexm/pkg/step/helpers/bom/binary"
+)
+
+type StopHarborServiceStep struct {
+	step.Base
+	RemoteInstallDir string
+}
+
+type StopHarborServiceStepBuilder struct {
+	step.Builder[StopHarborServiceStepBuilder, *StopHarborServiceStep]
+}
+
+func NewStopHarborServiceStepBuilder(ctx runtime.Context, instanceName string) *StopHarborServiceStepBuilder {
+	provider := binary.NewBinaryProvider(&ctx)
+	const representativeArch = "amd64"
+	binaryInfo, err := provider.GetBinary(binary.ComponentHarbor, representativeArch)
+
+	if err != nil || binaryInfo == nil {
+		return nil
+	}
+
+	cfg := ctx.GetClusterConfig().Spec
+	localCfg := cfg.Registry.LocalDeployment
+
+	if localCfg == nil || localCfg.Type != "harbor" {
+		return nil
+	}
+
+	installRoot := "/opt"
+	if localCfg.DataRoot != "" {
+		installRoot = localCfg.DataRoot
+	}
+
+	s := &StopHarborServiceStep{
+		RemoteInstallDir: filepath.Join(installRoot, "harbor"),
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Stop Harbor services on the registry node", s.Base.Meta.Name)
+	s.Base.Sudo = false
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 10 * time.Minute
+
+	b := new(StopHarborServiceStepBuilder).Init(s)
+	return b
+}
+
+func (s *StopHarborServiceStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *StopHarborServiceStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	// Check if key harbor services are running. If not, the step is done.
+	checkCmd := "docker ps --filter name=harbor-core --filter status=running --format '{{.Names}}'"
+	output, err := runner.Run(ctx.GoContext(), conn, checkCmd, s.Sudo)
+	if err != nil {
+		logger.Warnf("Failed to check for running harbor-core container, will attempt to stop anyway. Error: %v", err)
+		return false, nil
+	}
+
+	if !strings.Contains(output, "harbor-core") {
+		logger.Info("Harbor core container is not running. Step is done.")
+		return true, nil
+	}
+
+	logger.Info("Harbor core container is running. Stop is required.")
+	return false, nil
+}
+
+func (s *StopHarborServiceStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	composeFilePath := filepath.Join(s.RemoteInstallDir, "docker-compose.yml")
+	if exists, _ := runner.Exists(ctx.GoContext(), conn, composeFilePath); !exists {
+		logger.Warnf("Harbor docker-compose.yml not found at '%s', assuming services are already stopped.", composeFilePath)
+		return nil
+	}
+
+	stopCmd := fmt.Sprintf("cd %s && docker-compose down", s.RemoteInstallDir)
+	logger.Infof("Executing Harbor stop command on remote host: %s", stopCmd)
+
+	output, err := runner.Run(ctx.GoContext(), conn, stopCmd, s.Sudo)
+	if err != nil {
+		logger.Errorf("Harbor stop failed. Full output:\n%s", output)
+		return fmt.Errorf("failed to execute docker-compose down: %w", err)
+	}
+
+	logger.Info("Harbor services stopped successfully.")
+	logger.Debugf("Harbor stop output:\n%s", output)
+	return nil
+}
+
+func (s *StopHarborServiceStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return nil
+	}
+
+	installScriptPath := filepath.Join(s.RemoteInstallDir, "install.sh")
+	if exists, _ := runner.Exists(ctx.GoContext(), conn, installScriptPath); !exists {
+		logger.Warnf("Harbor install script not found at '%s', cannot run start for rollback.", installScriptPath)
+		return nil
+	}
+
+	startCmd := fmt.Sprintf("cd %s && ./install.sh", s.RemoteInstallDir)
+	logger.Warnf("Rolling back by running start command: %s", startCmd)
+
+	if _, err := runner.Run(ctx.GoContext(), conn, startCmd, s.Sudo); err != nil {
+		logger.Errorf("Failed to run start command during rollback: %v", err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*StopHarborServiceStep)(nil)

--- a/pkg/step/kubernetes/kube-controller-manager/disable_kube_controller_manager.go
+++ b/pkg/step/kubernetes/kube-controller-manager/disable_kube_controller_manager.go
@@ -1,0 +1,113 @@
+package kube_controller_manager
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type DisableKubeControllerManagerStep struct {
+	step.Base
+	ServiceName string
+}
+
+type DisableKubeControllerManagerStepBuilder struct {
+	step.Builder[DisableKubeControllerManagerStepBuilder, *DisableKubeControllerManagerStep]
+}
+
+func NewDisableKubeControllerManagerStepBuilder(ctx runtime.Context, instanceName string) *DisableKubeControllerManagerStepBuilder {
+	s := &DisableKubeControllerManagerStep{
+		ServiceName: "kube-controller-manager.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Disable kube-controller-manager service", s.Base.Meta.Name)
+	s.Base.Sudo = true
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(DisableKubeControllerManagerStepBuilder).Init(s)
+	return b
+}
+
+func (s *DisableKubeControllerManagerStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *DisableKubeControllerManagerStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	enabled, err := runner.IsServiceEnabled(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is enabled, assuming it is. Error: %v", s.ServiceName, err)
+		return false, nil
+	}
+
+	if !enabled {
+		logger.Infof("Service '%s' is already disabled. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is enabled. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *DisableKubeControllerManagerStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Disabling service: %s", s.ServiceName)
+	if err := runner.DisableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to disable service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' disabled successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *DisableKubeControllerManagerStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot enable service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by enabling service: %s", s.ServiceName)
+	if err := runner.EnableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to enable service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*DisableKubeControllerManagerStep)(nil)

--- a/pkg/step/kubernetes/kube-controller-manager/stop_kube_controller_manager.go
+++ b/pkg/step/kubernetes/kube-controller-manager/stop_kube_controller_manager.go
@@ -1,0 +1,113 @@
+package kube_controller_manager
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type StopKubeControllerManagerStep struct {
+	step.Base
+	ServiceName string
+}
+
+type StopKubeControllerManagerStepBuilder struct {
+	step.Builder[StopKubeControllerManagerStepBuilder, *StopKubeControllerManagerStep]
+}
+
+func NewStopKubeControllerManagerStepBuilder(ctx runtime.Context, instanceName string) *StopKubeControllerManagerStepBuilder {
+	s := &StopKubeControllerManagerStep{
+		ServiceName: "kube-controller-manager.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Stop kube-controller-manager service", s.Base.Meta.Name)
+	s.Base.Sudo = false
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(StopKubeControllerManagerStepBuilder).Init(s)
+	return b
+}
+
+func (s *StopKubeControllerManagerStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *StopKubeControllerManagerStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	active, err := runner.IsServiceActive(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is active, assuming it is not. Error: %v", s.ServiceName, err)
+		return false, nil // Assume it's not active, proceed with stop just in case
+	}
+
+	if !active {
+		logger.Infof("Service '%s' is already inactive. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is active. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *StopKubeControllerManagerStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Stopping service: %s", s.ServiceName)
+	if err := runner.StopService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to stop service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' stopped successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *StopKubeControllerManagerStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot start service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by starting service: %s", s.ServiceName)
+	if err := runner.StartService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to start service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*StopKubeControllerManagerStep)(nil)

--- a/pkg/step/kubernetes/kube-proxy/disable_kube_proxy.go
+++ b/pkg/step/kubernetes/kube-proxy/disable_kube_proxy.go
@@ -1,0 +1,113 @@
+package kube_proxy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type DisableKubeProxyStep struct {
+	step.Base
+	ServiceName string
+}
+
+type DisableKubeProxyStepBuilder struct {
+	step.Builder[DisableKubeProxyStepBuilder, *DisableKubeProxyStep]
+}
+
+func NewDisableKubeProxyStepBuilder(ctx runtime.Context, instanceName string) *DisableKubeProxyStepBuilder {
+	s := &DisableKubeProxyStep{
+		ServiceName: "kube-proxy.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Disable kube-proxy service", s.Base.Meta.Name)
+	s.Base.Sudo = true
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(DisableKubeProxyStepBuilder).Init(s)
+	return b
+}
+
+func (s *DisableKubeProxyStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *DisableKubeProxyStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	enabled, err := runner.IsServiceEnabled(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is enabled, assuming it is. Error: %v", s.ServiceName, err)
+		return false, nil
+	}
+
+	if !enabled {
+		logger.Infof("Service '%s' is already disabled. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is enabled. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *DisableKubeProxyStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Disabling service: %s", s.ServiceName)
+	if err := runner.DisableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to disable service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' disabled successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *DisableKubeProxyStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot enable service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by enabling service: %s", s.ServiceName)
+	if err := runner.EnableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to enable service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*DisableKubeProxyStep)(nil)

--- a/pkg/step/kubernetes/kube-proxy/stop_kube_proxy.go
+++ b/pkg/step/kubernetes/kube-proxy/stop_kube_proxy.go
@@ -1,0 +1,113 @@
+package kube_proxy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type StopKubeProxyStep struct {
+	step.Base
+	ServiceName string
+}
+
+type StopKubeProxyStepBuilder struct {
+	step.Builder[StopKubeProxyStepBuilder, *StopKubeProxyStep]
+}
+
+func NewStopKubeProxyStepBuilder(ctx runtime.Context, instanceName string) *StopKubeProxyStepBuilder {
+	s := &StopKubeProxyStep{
+		ServiceName: "kube-proxy.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Stop kube-proxy service", s.Base.Meta.Name)
+	s.Base.Sudo = true
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(StopKubeProxyStepBuilder).Init(s)
+	return b
+}
+
+func (s *StopKubeProxyStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *StopKubeProxyStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	active, err := runner.IsServiceActive(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is active, assuming it is not. Error: %v", s.ServiceName, err)
+		return false, nil
+	}
+
+	if !active {
+		logger.Infof("Service '%s' is already inactive. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is active. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *StopKubeProxyStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Stopping service: %s", s.ServiceName)
+	if err := runner.StopService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to stop service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' stopped successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *StopKubeProxyStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot start service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by starting service: %s", s.ServiceName)
+	if err := runner.StartService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to start service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*StopKubeProxyStep)(nil)

--- a/pkg/step/kubernetes/kube-scheduler/disable_kube_scheduler.go
+++ b/pkg/step/kubernetes/kube-scheduler/disable_kube_scheduler.go
@@ -1,0 +1,113 @@
+package kube_scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type DisableKubeSchedulerStep struct {
+	step.Base
+	ServiceName string
+}
+
+type DisableKubeSchedulerStepBuilder struct {
+	step.Builder[DisableKubeSchedulerStepBuilder, *DisableKubeSchedulerStep]
+}
+
+func NewDisableKubeSchedulerStepBuilder(ctx runtime.Context, instanceName string) *DisableKubeSchedulerStepBuilder {
+	s := &DisableKubeSchedulerStep{
+		ServiceName: "kube-scheduler.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Disable kube-scheduler service", s.Base.Meta.Name)
+	s.Base.Sudo = true
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(DisableKubeSchedulerStepBuilder).Init(s)
+	return b
+}
+
+func (s *DisableKubeSchedulerStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *DisableKubeSchedulerStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	enabled, err := runner.IsServiceEnabled(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is enabled, assuming it is. Error: %v", s.ServiceName, err)
+		return false, nil
+	}
+
+	if !enabled {
+		logger.Infof("Service '%s' is already disabled. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is enabled. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *DisableKubeSchedulerStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Disabling service: %s", s.ServiceName)
+	if err := runner.DisableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to disable service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' disabled successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *DisableKubeSchedulerStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot enable service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by enabling service: %s", s.ServiceName)
+	if err := runner.EnableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to enable service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*DisableKubeSchedulerStep)(nil)

--- a/pkg/step/kubernetes/kube-scheduler/stop_kube_scheduler.go
+++ b/pkg/step/kubernetes/kube-scheduler/stop_kube_scheduler.go
@@ -1,0 +1,113 @@
+package kube_scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type StopKubeSchedulerStep struct {
+	step.Base
+	ServiceName string
+}
+
+type StopKubeSchedulerStepBuilder struct {
+	step.Builder[StopKubeSchedulerStepBuilder, *StopKubeSchedulerStep]
+}
+
+func NewStopKubeSchedulerStepBuilder(ctx runtime.Context, instanceName string) *StopKubeSchedulerStepBuilder {
+	s := &StopKubeSchedulerStep{
+		ServiceName: "kube-scheduler.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Stop kube-scheduler service", s.Base.Meta.Name)
+	s.Base.Sudo = true
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(StopKubeSchedulerStepBuilder).Init(s)
+	return b
+}
+
+func (s *StopKubeSchedulerStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *StopKubeSchedulerStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	active, err := runner.IsServiceActive(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is active, assuming it is not. Error: %v", s.ServiceName, err)
+		return false, nil
+	}
+
+	if !active {
+		logger.Infof("Service '%s' is already inactive. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is active. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *StopKubeSchedulerStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Stopping service: %s", s.ServiceName)
+	if err := runner.StopService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to stop service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' stopped successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *StopKubeSchedulerStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot start service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by starting service: %s", s.ServiceName)
+	if err := runner.StartService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to start service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*StopKubeSchedulerStep)(nil)

--- a/pkg/step/kubernetes/kubelet/disable_kubelet.go
+++ b/pkg/step/kubernetes/kubelet/disable_kubelet.go
@@ -1,0 +1,113 @@
+package kubelet
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type DisableKubeletStep struct {
+	step.Base
+	ServiceName string
+}
+
+type DisableKubeletStepBuilder struct {
+	step.Builder[DisableKubeletStepBuilder, *DisableKubeletStep]
+}
+
+func NewDisableKubeletStepBuilder(ctx runtime.Context, instanceName string) *DisableKubeletStepBuilder {
+	s := &DisableKubeletStep{
+		ServiceName: "kubelet.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Disable kubelet service", s.Base.Meta.Name)
+	s.Base.Sudo = true
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(DisableKubeletStepBuilder).Init(s)
+	return b
+}
+
+func (s *DisableKubeletStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *DisableKubeletStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	enabled, err := runner.IsServiceEnabled(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is enabled, assuming it is. Error: %v", s.ServiceName, err)
+		return false, nil
+	}
+
+	if !enabled {
+		logger.Infof("Service '%s' is already disabled. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is enabled. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *DisableKubeletStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Disabling service: %s", s.ServiceName)
+	if err := runner.DisableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to disable service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' disabled successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *DisableKubeletStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot enable service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by enabling service: %s", s.ServiceName)
+	if err := runner.EnableService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to enable service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*DisableKubeletStep)(nil)

--- a/pkg/step/kubernetes/kubelet/stop_kubelet.go
+++ b/pkg/step/kubernetes/kubelet/stop_kubelet.go
@@ -1,0 +1,113 @@
+package kubelet
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mensylisir/kubexm/pkg/runtime"
+	"github.com/mensylisir/kubexm/pkg/spec"
+	"github.com/mensylisir/kubexm/pkg/step"
+)
+
+type StopKubeletStep struct {
+	step.Base
+	ServiceName string
+}
+
+type StopKubeletStepBuilder struct {
+	step.Builder[StopKubeletStepBuilder, *StopKubeletStep]
+}
+
+func NewStopKubeletStepBuilder(ctx runtime.Context, instanceName string) *StopKubeletStepBuilder {
+	s := &StopKubeletStep{
+		ServiceName: "kubelet.service",
+	}
+
+	s.Base.Meta.Name = instanceName
+	s.Base.Meta.Description = fmt.Sprintf("[%s]>>Stop kubelet service", s.Base.Meta.Name)
+	s.Base.Sudo = true
+	s.Base.IgnoreError = false
+	s.Base.Timeout = 3 * time.Minute
+
+	b := new(StopKubeletStepBuilder).Init(s)
+	return b
+}
+
+func (s *StopKubeletStep) Meta() *spec.StepMeta {
+	return &s.Base.Meta
+}
+
+func (s *StopKubeletStep) Precheck(ctx runtime.ExecutionContext) (isDone bool, err error) {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Precheck")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return false, err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return false, err
+	}
+
+	active, err := runner.IsServiceActive(ctx.GoContext(), conn, facts, s.ServiceName)
+	if err != nil {
+		logger.Warnf("Failed to check if service '%s' is active, assuming it is not. Error: %v", s.ServiceName, err)
+		return false, nil
+	}
+
+	if !active {
+		logger.Infof("Service '%s' is already inactive. Step is done.", s.ServiceName)
+		return true, nil
+	}
+
+	logger.Infof("Service '%s' is active. Step needs to run.", s.ServiceName)
+	return false, nil
+}
+
+func (s *StopKubeletStep) Run(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Run")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		return err
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Stopping service: %s", s.ServiceName)
+	if err := runner.StopService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		return fmt.Errorf("failed to stop service '%s' on host %s: %w", s.ServiceName, ctx.GetHost().GetName(), err)
+	}
+
+	logger.Infof("Service '%s' stopped successfully.", s.ServiceName)
+	return nil
+}
+
+func (s *StopKubeletStep) Rollback(ctx runtime.ExecutionContext) error {
+	logger := ctx.GetLogger().With("step", s.Base.Meta.Name, "host", ctx.GetHost().GetName(), "phase", "Rollback")
+	runner := ctx.GetRunner()
+	conn, err := ctx.GetCurrentHostConnector()
+	if err != nil {
+		logger.Errorf("Failed to get connector for rollback: %v", err)
+		return nil
+	}
+
+	facts, err := runner.GatherFacts(ctx.GoContext(), conn)
+	if err != nil {
+		logger.Warnf("Failed to gather facts during rollback, cannot start service gracefully. Error: %v", err)
+		return nil
+	}
+
+	logger.Warnf("Rolling back by starting service: %s", s.ServiceName)
+	if err := runner.StartService(ctx.GoContext(), conn, facts, s.ServiceName); err != nil {
+		logger.Errorf("Failed to start service '%s' during rollback: %v", s.ServiceName, err)
+	}
+
+	return nil
+}
+
+var _ step.Step = (*StopKubeletStep)(nil)


### PR DESCRIPTION
This commit introduces missing lifecycle management steps (`stop`, `disable`, `restart`) for several components and improves idempotency as requested.

- For the Harbor component (docker-compose based):
  - Improves the idempotency check for the start step by verifying multiple key containers.
  - Adds a non-destructive `stop` step (`docker-compose down`) to complement the existing destructive `stop-and-remove` step (`docker-compose down -v`).
  - Adds a `restart` step.

- For Kubernetes components (`kube-controller-manager`, `kube-proxy`, `kube-scheduler`, `kubelet`):
  - Adds the missing `stop` and `disable` steps, which use `systemctl` via runner helpers. The corresponding `start`, `restart`, and `enable` steps already existed.